### PR TITLE
Add DataFilter component to allow for basic filtering of data on Views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ TABLE="your_db_table"
 EMBED_MEDIA="NO"
 MEDIA_BASE_PATH="./media"
 
+# Front end dropdown filter options
+FRONT_END_FILTERING="YES"
+FRONT_END_FILTER_FIELD="Category"
+
 # Port to serve app
 PORT="8080"
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This is a [Nuxt](https://nuxt.com/) tool for GuardianConnector which builds an A
 
 To get started, copy `.env.example` to `.env` and add your database and table information, and a Mapbox access token.
 
-**Database:** to use SQLite instead of Postgres, set  `SQLITE` to `YES` and provide a path value for `SQLITE_DB_PATH`.
+**Database:** To use SQLite instead of Postgres, set  `SQLITE` to `YES` and provide a path value for `SQLITE_DB_PATH`.
 
-**Media attachments:** if your data is storing filenames for media attachments, you can embed them by setting `EMBED_MEDIA` to `YES`, and by providing the path to the exact location where media attachments are stored in `MEDIA_PATH`.
+**Media attachments:** If your data is storing filenames for media attachments, you can embed them by setting `EMBED_MEDIA` to `YES`, and by providing the path to the exact location where media attachments are stored in `MEDIA_PATH`.
+
+**Dropdown filter:** You can enable a dropdown that allows you to filter the data on your views. Set `FRONT_END_FILTERING` to `YES` and provide a value for `FRONT_END_FILTER_FIELD` (e.g. "Category" which could be a good choice for Mapeo data).
 
 **Unwanted columns and substrings:** Many outputs from data collection APIs have a lot of extraneous metadata fields that are not useful to the end user. See [docs/schema.md](docs/schema.md) for a list of these fields that are output by popular data collection APIs. You can determine which fields to filter out in `UNWANTED_COLUMNS` (exact column names will be filtered) and `UNWANTED_SUBSTRINGS` (all columns which include these substrings will be filtered).
 
@@ -28,6 +30,8 @@ $ yarn start
 # generate static project
 $ yarn generate
 ```
+
+Add `--hostname 0.0.0.0` if you want the app to be accessible across your local network.
 
 ## Deployment
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -27,6 +27,8 @@ interface EnvVars {
   MAPBOX_ZOOM: string;
   MAPBOX_PITCH: string;
   MAPBOX_BEARING: string;
+  FRONT_END_FILTERING: string;
+  FRONT_END_FILTER_FIELD: string;
 }
 
 const env = process.env as unknown as EnvVars;
@@ -45,6 +47,8 @@ const SQLITE_DB_PATH = env.SQLITE_DB_PATH ? env.SQLITE_DB_PATH.replace(/['"]+/g,
 const TABLE = env.TABLE ? env.TABLE.replace(/['"]+/g, '') : undefined;
 const UNWANTED_COLUMNS = env.UNWANTED_COLUMNS ? env.UNWANTED_COLUMNS.replace(/['"]+/g, '') : undefined;
 const UNWANTED_SUBSTRINGS = env.UNWANTED_SUBSTRINGS ? env.UNWANTED_SUBSTRINGS.replace(/['"]+/g, '') : undefined;
+const FRONT_END_FILTERING = env.FRONT_END_FILTERING ? env.FRONT_END_FILTERING.replace(/['"]+/g, '') : "NO";
+const FRONT_END_FILTER_FIELD = env.FRONT_END_FILTER_FIELD ? env.FRONT_END_FILTER_FIELD.replace(/['"]+/g, '') : undefined;
 const EMBED_MEDIA = env.EMBED_MEDIA.replace(/['"]+/g, '').toUpperCase() === 'YES' ? 'YES' : 'NO';
 const MEDIA_BASE_PATH = env.MEDIA_BASE_PATH ? env.MEDIA_BASE_PATH.replace(/['"]+/g, '') : undefined;
 const MAPBOX_ACCESS_TOKEN = env.MAPBOX_ACCESS_TOKEN ? env.MAPBOX_ACCESS_TOKEN.replace(/['"]+/g, '') : 'pk.ey';
@@ -108,8 +112,27 @@ app.get('/map', async (req: express.Request, res: express.Response) => {  try {
         // Transform data
     const transformedData = transformData(filteredGeoData)
 
-    res.json({ data: transformedData, imageExtensions: imageExtensions, audioExtensions: audioExtensions, videoExtensions: videoExtensions, embedMedia: EMBED_MEDIA, mediaBasePath: MEDIA_BASE_PATH, mapboxAccessToken: MAPBOX_ACCESS_TOKEN, mapboxStyle: MAPBOX_STYLE, mapboxProjection: MAPBOX_PROJECTION, mapboxLatitude: MAPBOX_CENTER_LATITUDE, mapboxLongitude: MAPBOX_CENTER_LONGITUDE, mapboxZoom: MAPBOX_ZOOM, mapboxPitch: MAPBOX_PITCH, mapboxBearing: MAPBOX_BEARING });
-    
+    const response = {
+      data: transformedData, 
+      filterData: FRONT_END_FILTERING === "YES",
+      filterField: FRONT_END_FILTER_FIELD,
+      imageExtensions: imageExtensions, 
+      audioExtensions: audioExtensions, 
+      videoExtensions: videoExtensions, 
+      embedMedia: EMBED_MEDIA === "YES",
+      mediaBasePath: MEDIA_BASE_PATH, 
+      mapboxAccessToken: MAPBOX_ACCESS_TOKEN, 
+      mapboxStyle: MAPBOX_STYLE, 
+      mapboxProjection: MAPBOX_PROJECTION, 
+      mapboxLatitude: MAPBOX_CENTER_LATITUDE, 
+      mapboxLongitude: MAPBOX_CENTER_LONGITUDE, 
+      mapboxZoom: MAPBOX_ZOOM, 
+      mapboxPitch: MAPBOX_PITCH, 
+      mapboxBearing: MAPBOX_BEARING
+    };
+
+    res.json(response);
+
   } catch (error:any) {
     console.error('Error fetching data on API side:', error.message);
     res.status(500).json({ error: error.message });
@@ -127,8 +150,19 @@ app.get('/gallery', async (req: express.Request, res: express.Response) => {  tr
     // Transform data
     const transformedData = transformData(dataWithFilesOnly)
 
-    res.json({ data: transformedData, imageExtensions: imageExtensions, audioExtensions: audioExtensions, videoExtensions: videoExtensions, embedMedia: EMBED_MEDIA, mediaBasePath: MEDIA_BASE_PATH });
+    const response = {
+      data: transformedData, 
+      filterData: FRONT_END_FILTERING === "YES",
+      filterField: FRONT_END_FILTER_FIELD,
+      imageExtensions: imageExtensions, 
+      audioExtensions: audioExtensions, 
+      videoExtensions: videoExtensions, 
+      embedMedia: EMBED_MEDIA === "YES",
+      mediaBasePath: MEDIA_BASE_PATH
+    };
 
+    res.json(response);
+    
   } catch (error:any) {
     console.error('Error fetching data on API side:', error.message);
     res.status(500).json({ error: error.message });

--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="filter-modal">
-      <h4>Filter data:</h4>
+      <h4>Filter data by field: <strong>{{ filterField }}</strong> </h4>
       <select v-model="selectedValue" @change="emitFilter" v-if="uniqueValues.length > 0">
         <option disabled value="">Select field</option>
         <option value="null">Show all data</option>
@@ -8,7 +8,7 @@
           {{ value }}
         </option>
       </select>
-      <p class="no-data" v-else><i>No data found that matches your filter string.</i></p>
+      <p class="no-data" v-else><i>No data found that matches {{ filterField }}.</i></p>
     </div>
   </template>
   

--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -1,0 +1,71 @@
+<template>
+    <div class="filter-modal">
+      <h4>Filter data:</h4>
+      <select v-model="selectedValue" @change="emitFilter" v-if="uniqueValues.length > 0">
+        <option disabled value="">Select field</option>
+        <option value="null">Show all data</option>
+        <option v-for="value in uniqueValues" :key="value" :value="value">
+          {{ value }}
+        </option>
+      </select>
+      <p class="no-data" v-else><i>No data found that matches your filter string.</i></p>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    props: ['data', 'filterField'],
+    data() {
+      return {
+        selectedValue: "",
+      };
+    },
+    computed: {
+      uniqueValues() {
+        const values = this.data
+          .map(item => item[this.filterField])
+          .filter(value => value !== null && value !== '' && value !== undefined);
+        console.log(values)
+        return [...new Set(values)];
+      },
+    },
+    methods: {
+      emitFilter() {
+        this.$emit('filter', this.selectedValue);
+      },
+    },
+  };
+  </script>
+  
+  <style scoped>
+  .filter-modal {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    min-width: 150px;
+    background: #f5f5f5;
+    padding: 10px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+    border-radius: 10px; /* Rounded corners */
+    z-index: 1000;
+    
+    h4 {
+      font-size: 1.2em;
+      margin: 0;
+      color: #333; 
+    }
+
+    select { 
+      width: 100%;
+      margin: 5px 0;
+      padding: 5px;
+    }
+
+    .no-data {
+      font-style: italic;
+      max-width: 150px;
+      color: #999;
+    }
+  }
+
+  </style>

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -4,7 +4,7 @@
     <Media
       v-for="filePath in filePaths"
       :key="filePath"
-      v-if="embedMedia === 'YES'"
+      v-if="embedMedia === true"
       :mediaBasePath="mediaBasePath"
       :filePath="filePath"
       :image-extensions="imageExtensions"

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -2,9 +2,9 @@
   <div class="feature p-4 rounded-lg shadow-lg">
     <!-- Conditional rendering depending on file extension -->
     <Media
+      v-if="embedMedia === true"
       v-for="filePath in filePaths"
       :key="filePath"
-      v-if="embedMedia === true"
       :mediaBasePath="mediaBasePath"
       :filePath="filePath"
       :image-extensions="imageExtensions"

--- a/components/Gallery.vue
+++ b/components/Gallery.vue
@@ -3,8 +3,16 @@
     id="galleryContainer"
     class="gallery p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
   >
+    <div class="sticky top-10 right-10 z-10">
+      <DataFilter
+          v-if="filterData === true"
+          :data="data"
+          :filter-field="filterField"
+          @filter="filter"
+      />
+    </div>
     <Feature
-      v-for="(feature, index) in data"
+      v-for="(feature, index) in filteredData"
       :key="index"
       :embed-media="embedMedia"
       :media-base-path="mediaBasePath"
@@ -19,11 +27,26 @@
 
 <script>
 import Feature from "@/components/Feature.vue";
+import DataFilter from "@/components/DataFilter.vue";
 import getFilePaths from "@/src/utils.ts";
 
 export default {
-  components: { Feature },
-  props: ["data", "imageExtensions", "audioExtensions", "videoExtensions", "embedMedia", "mediaBasePath"],
+  components: { Feature, DataFilter },
+  props: [
+    "data", 
+    "filterData",
+    "filterField",
+    "imageExtensions", 
+    "audioExtensions", 
+    "videoExtensions", 
+    "embedMedia", 
+    "mediaBasePath"
+  ],
+  data() {
+    return {
+      filteredData: this.data,
+    };
+  },
   computed: {
     allExtensions() {
       return [
@@ -35,6 +58,13 @@ export default {
   },
   methods: {
     getFilePaths: getFilePaths,
+    filter(value) {
+      if (value === 'null') {
+        this.filteredData = this.data;
+      } else {
+        this.filteredData = this.data.filter(item => item[this.filterField] === value);
+      }
+    },
   },
 };
 </script>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -23,6 +23,8 @@ export default {
   components: { FeaturePopup },
   props: [
     "data", 
+    "filterData",
+    "filterField",
     "imageExtensions", 
     "audioExtensions", 
     "videoExtensions",

--- a/pages/gallery.vue
+++ b/pages/gallery.vue
@@ -3,6 +3,8 @@
     <Gallery 
       v-if="embedMedia === 'YES' && dataFetched"
       :data="data"
+      :filter-data="filterData"
+      :filter-field="filterField"
       :image-extensions="imageExtensions"
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
@@ -29,10 +31,12 @@ export default {
     return {
       dataFetched: false,
       data: [],
+      filterData: false,
+      filterField: '',
       imageExtensions: [],
       audioExtensions: [],
       videoExtensions: [],
-      embedMedia: '',
+      embedMedia: false,
       mediaBasePath: ''
     };
   },
@@ -42,6 +46,8 @@ export default {
         apiKey = apiKey.replace(/['"]+/g, '');
         const response = await this.$axios.$get('api/gallery', { headers: { 'x-api-key': apiKey } });
         this.data = response.data;
+        this.filterData = response.filterData;
+        this.filterField = response.filterField;
         this.imageExtensions = response.imageExtensions;
         this.audioExtensions = response.audioExtensions;
         this.videoExtensions = response.videoExtensions;

--- a/pages/gallery.vue
+++ b/pages/gallery.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Gallery 
-      v-if="embedMedia === 'YES' && dataFetched"
+      v-if="embedMedia === true && dataFetched"
       :data="data"
       :filter-data="filterData"
       :filter-field="filterField"
@@ -11,7 +11,7 @@
       :embed-media="embedMedia"
       :media-base-path="mediaBasePath"
     />
-    <h3 v-if="embedMedia !== 'YES' && dataFetched">
+    <h3 v-if="embedMedia !== true && dataFetched">
       GuardianConnector Views Gallery is not available. Please activate media embedding.
     </h3>
 </div>

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -3,6 +3,8 @@
     <Map
       v-if="dataFetched"
       :data="data"
+      :filter-data="filterData"
+      :filter-field="filterField"
       :image-extensions="imageExtensions"
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
@@ -34,10 +36,12 @@ export default {
     return {
       dataFetched: false,
       data: [],
+      filterData: false,
+      filterField: '',
       imageExtensions: [],
       audioExtensions: [],
       videoExtensions: [],
-      embedMedia: '',
+      embedMedia: false,
       mediaBasePath: '',
       mapboxAccessToken: '',
       mapboxStyle: '',
@@ -55,6 +59,8 @@ export default {
       apiKey = apiKey.replace(/['"]+/g, '');
       const response = await this.$axios.$get('api/map', { headers: { 'x-api-key': apiKey } });
       this.data = response.data;
+      this.filterData = response.filterData;
+      this.filterField = response.filterField;
       this.imageExtensions = response.imageExtensions;
       this.audioExtensions = response.audioExtensions;
       this.videoExtensions = response.videoExtensions;


### PR DESCRIPTION
Closes #3.

This PR:

1. Adds a `DataFilter` component which takes a prop `filterField` and matches it with `data` keys to populate the values of a dropdown. Dropdown selection invokes an `emitFilter()` method which then filters the data on the parent component (e.g. Map, Gallery).
2. Allows the `DataFilter` component can be enabled using an environmental var `FRONT_END_FILTERING` and uses an additional env var `FRONT_END_FILTER_FIELD` as the `filterField` key.
3. Adds `DataFilter` to `Map` and `Gallery` components.

I considered having two dropdowns: one to select a column (key), and the other to select values (similar to what [Terrastories](https://github.com/terrastories/terrastories) does). However, I felt that this required more validation with our users, so I opted for this initial approach for now which will be a great value add for Mapeo maps or other datasets where there is one primary key.