### PR TITLE
Update Vue pages to better handle retrieval & messaging

### DIFF
--- a/pages/gallery.vue
+++ b/pages/gallery.vue
@@ -40,7 +40,7 @@ export default {
       mediaBasePath: ''
     };
   },
-  async created() {
+  async mounted() {
       try {
         let apiKey = this.$config.apiKey;
         apiKey = apiKey.replace(/['"]+/g, '');
@@ -55,7 +55,7 @@ export default {
           headers['Authorization'] = `Bearer ${token}`;
         }
 
-        const response = await this.$axios.$get('api/gallery', { headers });
+        const response = await this.$axios.$get('/api/gallery', { headers });
         this.data = response.data;
         this.filterData = response.filterData;
         this.filterField = response.filterField;

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,7 +1,8 @@
 <template>
     <!-- <Login /> -->
-    <div class="flex items-center justify-center h-screen">
-      <button class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50" @click="loginWithAuth0">Login with Auth0</button>
+    <div class="flex flex-col items-center justify-center h-screen">
+      <button class="px-4 py-2 mb-4 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50" @click="loginWithAuth0">Login with Auth0</button>
+      <p v-if="errorMessage" class="text-red-500 text-xs italic">{{ errorMessage }}</p>
     </div>
 </template>
   
@@ -9,8 +10,22 @@
   // import Login from '~/components/Login.vue'
   
   export default {
+    data() {
+      return {
+        errorMessage: ""
+      };
+    },
     components: {
       // Login
+    },
+    mounted() {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const error = hashParams.get('error');
+      const errorDescription = hashParams.get('error_description');
+
+      if (error === 'access_denied') {
+        this.errorMessage = decodeURIComponent(errorDescription);
+      }
     },
     methods: {
       async loginWithAuth0() {

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -55,7 +55,7 @@ export default {
       mapbox3d: false
     };
   },
-  async created() {
+  async mounted() {
     try {
       let apiKey = this.$config.apiKey;
       apiKey = apiKey.replace(/['"]+/g, '');
@@ -70,7 +70,7 @@ export default {
         headers['Authorization'] = `Bearer ${token}`;
       }
       
-      const response = await this.$axios.$get('api/map', { headers });
+      const response = await this.$axios.$get('/api/map', { headers });
       this.data = response.data;
       this.filterData = response.filterData;
       this.filterField = response.filterField;


### PR DESCRIPTION
This PR implements several updates to the Vue pages:

* Make API requests when the page is mounted, not created (resolving a temporary server-side error being thrown).
* Decode and show auth0 error description on the login page. This will show messages like the following successful auth0 authentication attempt for a user that has not yet been approved by an auth0 admin to view the app:

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/bcb246d4-56ab-486a-9435-c5ab337292a4)
