### PR TITLE
Implement and style vue-select component

### DIFF
--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -1,70 +1,127 @@
 <template>
-    <div class="filter-modal">
-      <h4>Filter data by field: <strong>{{ filterField }}</strong> </h4>
-      <select v-model="selectedValue" @change="emitFilter" v-if="uniqueValues.length > 0">
-        <option disabled value="">Select field</option>
-        <option value="null">Show all data</option>
-        <option v-for="value in uniqueValues" :key="value" :value="value">
-          {{ value }}
-        </option>
-      </select>
-      <p class="no-data" v-else><i>No data found that matches {{ filterField }}.</i></p>
-    </div>
-  </template>
-  
-  <script>
-  export default {
-    props: ['data', 'filterField'],
-    data() {
-      return {
-        selectedValue: "",
-      };
-    },
-    computed: {
-      uniqueValues() {
-        const values = this.data
-          .map(item => item[this.filterField])
-          .filter(value => value !== null && value !== '' && value !== undefined);
-        return [...new Set(values)];
-      },
-    },
-    methods: {
-      emitFilter() {
-        this.$emit('filter', this.selectedValue);
-      },
-    },
-  };
-  </script>
-  
-  <style scoped>
-  .filter-modal {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    min-width: 150px;
-    background: #f5f5f5;
-    padding: 10px;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
-    border-radius: 10px; /* Rounded corners */
-    z-index: 1000;
-    
-    h4 {
-      font-size: 1.2em;
-      margin: 0;
-      color: #333; 
-    }
+  <div class="filter-modal">
+    <h4>
+      Filter data by field: <strong>{{ filterField }}</strong>
+    </h4>
+    <v-select
+      multiple
+      :options="uniqueValues"
+      @input="emitFilter"
+      label="label"
+      v-model="selectedValue"
+      v-if="uniqueValues.length > 0"
+    >
+      <!-- These are the options in the dropdown -->
+      <template v-slot:option="option">
+        <span
+          class="colored-dot"
+          v-if="showColoredDot"
+          :style="{ backgroundColor: option.color }"
+        ></span>
+        {{ option.label }}
+      </template>
+      <!-- This is what shows in the listbox when selected -->
+      <template v-slot:selected-option="option">
+        <span
+          class="colored-dot"
+          v-if="showColoredDot"
+          :style="{ backgroundColor: option.color }"
+        ></span>
+        {{ option.label }}
+      </template>
+    </v-select>
+  </div>
+</template>
 
-    select { 
-      width: 100%;
-      margin: 5px 0;
-      padding: 5px;
-    }
+<script>
+import vSelect from "vue-select";
+import "vue-select/dist/vue-select.css";
 
-    .no-data {
-      font-style: italic;
-      max-width: 150px;
-      color: #999;
+export default {
+  components: { vSelect },
+  props: ["data", "filterField", "showColoredDot"],
+  data() {
+    return {
+      selectedValue: [],
+      defaultColor: "#ffffff",
+    };
+  },
+  computed: {
+    uniqueValues() {
+      const values = this.data
+        .map((item) => ({
+          label: item[this.filterField],
+          value: item[this.filterField],
+          color: item["filter-color"]
+            ? item["filter-color"]
+            : this.defaultColor,
+        }))
+        .filter(
+          (item) =>
+            item.value !== null && item.value !== "" && item.value !== undefined
+        );
+
+      // Filter out the selected values
+      const filteredValues = values.filter(
+        (value) => !this.selectedValue.map((v) => v.value).includes(value.value)
+      );
+
+      return [
+        ...new Map(filteredValues.map((item) => [item.value, item])).values(),
+      ];
+    },
+  },
+  methods: {
+    emitFilter() {
+      if (this.selectedValue.length > 0) {
+        const labels = this.selectedValue.map((item) => item.label);
+        this.$emit("filter", labels);
+      } else {
+        this.$emit("filter", "null");
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.filter-modal {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  min-width: 325px;
+  background: #f5f5f5;
+  padding: 10px;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 10px; /* Rounded corners */
+  z-index: 1000;
+
+  h4 {
+    font-size: 1.2em;
+    margin: 0;
+    color: #333;
+  }
+
+  .v-select {
+    width: 100%;
+    margin: 5px 0;
+    padding: 5px;
+
+    --vs-selected-bg: #f9f9f9;
+
+    .colored-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 5px;
     }
   }
 
-  </style>
+  .no-data {
+    font-style: italic;
+    max-width: 150px;
+    color: #999;
+  }
+}
+</style>

--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -9,7 +9,6 @@
       @input="emitFilter"
       label="label"
       v-model="selectedValue"
-      v-if="uniqueValues.length > 0"
     >
       <!-- These are the options in the dropdown -->
       <template v-slot:option="option">
@@ -90,6 +89,7 @@ export default {
   top: 10px;
   right: 10px;
   min-width: 325px;
+  max-width: 600px;
   background: #f5f5f5;
   padding: 10px;
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);

--- a/components/Gallery.vue
+++ b/components/Gallery.vue
@@ -5,23 +5,23 @@
   >
     <div class="sticky top-10 right-10 z-10">
       <DataFilter
-          v-if="filterData === true"
-          :data="data"
-          :filter-field="filterField"
-          @filter="filter"
+        v-if="filterData === true"
+        :data="data"
+        :filter-field="filterField"
+        @filter="filter"
       />
     </div>
-      <Feature
-        v-for="(feature, index) in paginatedData"
-        :key="index"
-        :embed-media="embedMedia"
-        :media-base-path="mediaBasePath"
-        :file-paths="getFilePaths(feature, allExtensions)"
-        :feature="feature"
-        :image-extensions="imageExtensions"
-        :audio-extensions="audioExtensions"
-        :video-extensions="videoExtensions"
-      />
+    <Feature
+      v-for="(feature, index) in paginatedData"
+      :key="index"
+      :embed-media="embedMedia"
+      :media-base-path="mediaBasePath"
+      :file-paths="getFilePaths(feature, allExtensions)"
+      :feature="feature"
+      :image-extensions="imageExtensions"
+      :audio-extensions="audioExtensions"
+      :video-extensions="videoExtensions"
+    />
   </div>
 </template>
 
@@ -33,20 +33,20 @@ import getFilePaths from "@/src/utils.ts";
 export default {
   components: { Feature, DataFilter },
   props: [
-    "data", 
+    "data",
     "filterData",
     "filterField",
-    "imageExtensions", 
-    "audioExtensions", 
-    "videoExtensions", 
-    "embedMedia", 
-    "mediaBasePath"
+    "imageExtensions",
+    "audioExtensions",
+    "videoExtensions",
+    "embedMedia",
+    "mediaBasePath",
   ],
   data() {
     return {
       filteredData: this.data,
       currentPage: 1,
-      itemsPerPage: 100
+      itemsPerPage: 100,
     };
   },
   computed: {
@@ -64,23 +64,25 @@ export default {
     },
   },
   mounted() {
-    window.addEventListener('scroll', this.handleScroll);
+    window.addEventListener("scroll", this.handleScroll);
   },
   beforeDestroy() {
-    window.removeEventListener('scroll', this.handleScroll);
+    window.removeEventListener("scroll", this.handleScroll);
   },
   methods: {
     handleScroll() {
-      if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
         this.currentPage++;
       }
     },
     getFilePaths: getFilePaths,
-    filter(value) {
-      if (value === 'null') {
+    filter(values) {
+      if (values.includes("null")) {
         this.filteredData = this.data;
       } else {
-        this.filteredData = this.data.filter(item => item[this.filterField] === value);
+        this.filteredData = this.data.filter((item) =>
+          values.includes(item[this.filterField])
+        );
       }
     },
   },

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -4,6 +4,7 @@
       v-if="filterData === true"
       :data="data"
       :filter-field="filterField"
+      :show-colored-dot="true"
       @filter="filter"
     />
     <FeaturePopup
@@ -45,7 +46,7 @@ export default {
     "mapboxZoom",
     "mapboxPitch",
     "mapboxBearing",
-    "mapbox3d"
+    "mapbox3d",
   ],
   data() {
     return {
@@ -66,11 +67,13 @@ export default {
     },
   },
   methods: {
-    filter(value) {
-      if (value === 'null') {
+    filter(values) {
+      if (values.includes("null")) {
         this.filteredData = [...this.processedData];
       } else {
-        this.filteredData = this.processedData.filter(item => item[this.filterField] === value);
+        this.filteredData = this.processedData.filter((item) =>
+          values.includes(item[this.filterField])
+        );
       }
       this.addDataToMap(); // Call this method to update the map data
     },
@@ -85,79 +88,83 @@ export default {
     addDataToMap() {
       // Remove existing data layers from the map
       if (this.map) {
-        this.map.getStyle().layers.forEach(layer => {
-          if (layer.id.startsWith('data-layer')) {
+        this.map.getStyle().layers.forEach((layer) => {
+          if (layer.id.startsWith("data-layer")) {
             if (this.map.getLayer(layer.id)) {
               this.map.removeLayer(layer.id);
             }
           }
         });
-        if (this.map.getSource('data-source')) {
-          this.map.removeSource('data-source');
+        if (this.map.getSource("data-source")) {
+          this.map.removeSource("data-source");
         }
       }
 
       // Create a GeoJSON source with all the features
       const geoJsonSource = {
         type: "FeatureCollection",
-        features: this.filteredData.map(feature => ({
+        features: this.filteredData.map((feature) => ({
           type: "Feature",
           geometry: {
             type: feature.Geotype,
             coordinates: feature.Geocoordinates,
           },
           properties: {
-            feature
+            feature,
           },
         })),
       };
 
       // Add the source to the map
-      this.map.addSource('data-source', {
+      this.map.addSource("data-source", {
         type: "geojson",
         data: geoJsonSource,
       });
 
       // Add a layer for Point features
       this.map.addLayer({
-        id: 'data-layer-point',
-        type: 'circle',
-        source: 'data-source',
-        filter: ['==', '$type', 'Point'],
+        id: "data-layer-point",
+        type: "circle",
+        source: "data-source",
+        filter: ["==", "$type", "Point"],
         paint: {
-          'circle-radius': 6,
-          'circle-color': ['get', 'filter-color', ['get', 'feature']],
-          'circle-stroke-width': 2,
-          'circle-stroke-color': '#fff'
+          "circle-radius": 6,
+          "circle-color": ["get", "filter-color", ["get", "feature"]],
+          "circle-stroke-width": 2,
+          "circle-stroke-color": "#fff",
         },
       });
 
       // Add a layer for LineString features
       this.map.addLayer({
-        id: 'data-layer-linestring',
-        type: 'line',
-        source: 'data-source',
-        filter: ['==', '$type', 'LineString'],
+        id: "data-layer-linestring",
+        type: "line",
+        source: "data-source",
+        filter: ["==", "$type", "LineString"],
         paint: {
-          'line-color': ['get', 'filter-color', ['get', 'feature']],
-          'line-width': 2,
+          "line-color": ["get", "filter-color", ["get", "feature"]],
+          "line-width": 2,
         },
       });
 
       // Add a layer for Polygon features
       this.map.addLayer({
-        id: 'data-layer-polygon',
-        type: 'fill',
-        source: 'data-source',
-        filter: ['==', '$type', 'Polygon'],
+        id: "data-layer-polygon",
+        type: "fill",
+        source: "data-source",
+        filter: ["==", "$type", "Polygon"],
         paint: {
-          'fill-color': ['get', 'filter-color', ['get', 'feature']],
-          'fill-opacity': 0.5,
+          "fill-color": ["get", "filter-color", ["get", "feature"]],
+          "fill-opacity": 0.5,
         },
       });
 
       // Add event listeners
-      ['data-layer-point', 'data-layer-linestring', 'data-layer-polygon'].forEach(layerId => {
+      [
+        "data-layer-point",
+        "data-layer-linestring",
+        "data-layer-polygon",
+      ].forEach((layerId) => {
         this.map.on("mouseenter", layerId, () => {
           this.map.getCanvas().style.cursor = "pointer";
         });
@@ -166,7 +173,7 @@ export default {
         });
         this.map.on("click", layerId, (e) => {
           let featureObject = JSON.parse(e.features[0].properties.feature);
-          delete featureObject['filter-color'];
+          delete featureObject["filter-color"];
           this.selectedFeature = featureObject;
           this.showSidebar = true;
         });
@@ -180,10 +187,7 @@ export default {
       container: "map",
       style: this.mapboxStyle || "mapbox://styles/mapbox/streets-v12",
       projection: this.mapboxProjection || "globe",
-      center: [
-        this.mapboxLongitude || 0,
-        this.mapboxLatitude || -15
-      ],
+      center: [this.mapboxLongitude || 0, this.mapboxLatitude || -15],
       zoom: this.mapboxZoom || 2.5,
       pitch: this.mapboxPitch || 0,
       bearing: this.mapboxBearing || 0,
@@ -193,16 +197,15 @@ export default {
     this.processedData = this.data;
 
     this.map.on("load", () => {
-
       // Add 3D Terrain if set in env var
       if (this.mapbox3d) {
-        this.map.addSource('mapbox-dem', {
-          'type': 'raster-dem',
-          'url': 'mapbox://mapbox.mapbox-terrain-dem-v1',
-          'tileSize': 512,
-          'maxzoom': 14
+        this.map.addSource("mapbox-dem", {
+          type: "raster-dem",
+          url: "mapbox://mapbox.mapbox-terrain-dem-v1",
+          tileSize: 512,
+          maxzoom: 14,
         });
-        this.map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
+        this.map.setTerrain({ source: "mapbox-dem", exaggeration: 1.5 });
       }
 
       this.addDataToMap();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pg": "^8.11.3",
     "sqlite3": "^5.1.6",
     "vue": "^2.7.10",
+    "vue-select": "^3.20.2",
     "vue-server-renderer": "^2.7.10",
     "vue-template-compiler": "^2.7.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10207,6 +10207,11 @@ vue-router@^3.6.5:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.6.5.tgz#95847d52b9a7e3f1361cb605c8e6441f202afad8"
   integrity sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==
 
+vue-select@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.20.2.tgz#eaa15012b032c154d4fb51ac82ebeda2beeae54b"
+  integrity sha512-ZSzIDzyYsWZULGUxVp1h6u3yi9IZQBWX8r6kSudUI/I5J1HQKpBjRntvkrg6pr87xmm16kdChvHCDN+W84vTKw==
+
 vue-server-renderer@^2.7.10, vue-server-renderer@^2.7.14:
   version "2.7.14"
   resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz#986f3fdca63fbb38bb6834698f11e0d6a81f182f"


### PR DESCRIPTION
This PR adds and customizes a `vue-select` Component for dropdown filtering. `vue-select` is a great, feature rich select/dropdown/typeahead component Vue component. I am using it here to allow the user to do filtering using multiple selections, and to add a colored dot next to each selection that matches what is shown for the dots on the map. I also cleaned up some parts of both the `Map` and `Gallery` components.

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/f1d5f156-87b8-40f4-b472-115019236276)

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/3875aea8-efeb-46e7-9466-7cc2c399037a)

