### PR TITLE
Make it possible to set an authentication strategy (auth0, password, or none)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,14 @@ SQLITE_DB_PATH="./sql.db"
 # Port to serve app
 PORT="8080"
 
-# OPTION 1 FOR AUTHENTICATION: Password to access the app and generate JWT token
-USE_PASSWORD="NO"
-PASSWORD="guardian-connector"
+# Available auth0 strategy options: "auth0", "password", or "none"
+NUXT_ENV_AUTH_STRATEGY="auth0" 
 
-# Secret JWT key that can be used to bypass logging in for embedding purposes
+# If AUTH_STRATEGY is set to password, provide a password and generate a JWT token:
+PASSWORD="guardian-connector"
 SECRET_JWT_KEY="secret-jwt-key"
 
-# OPTION 2 FOR AUTHENTICATION: Auth0 credentials
+# If AUTH_STRATEGY is set to auth0, provide the credentials:
 NUXT_ENV_AUTH0_DOMAIN="domain.us.auth0.com"
 NUXT_ENV_AUTH0_CLIENT_ID=""
 NUXT_ENV_AUTH0_CLIENT_SECRET=""

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ To get started, copy `.env.example` to `.env` and add your database and table in
 
 **Database:** Provide your database information in the relevant variables. To use SQLite instead of Postgres, set `SQLITE` to `YES` and provide a path value for `SQLITE_DB_PATH` (you can ignore `DATABASE` and the `DB_` ones).
 
-**Authentication:** Authentication is optional. If you want to use authentication, set `USE_PASSWORD` to "YES". If not, your pages and components can be accessed without needing users to log in.
+**Authentication strategy:** GuardianConnector Views supports three different authentication strategies: auth0, password (from an environmental var) with JWT key, or none. Set your authentication strategy in `NUXT_ENV_AUTH_STRATEGY`.
 
-**Auth0 authentication:** GuardianConnector Views supports an auth0 strategy. Add your env variables for auth0 to get this to work. 
-
-**Local authentication:** GuardianConnector Views can be protected through password and a JavaScript Web Token using the local strategy. You can set the password using `PASSWORD`, and also set a `SECRET_JWT_KEY` to authenticate using the browser, by appending `?secret_key=` to the end of your path.
+* If you are using an auth0 strategy, then you need to provide a domain, client ID, client secret, audience, and base URL.
+* If you are using a password strategy, then you need to provide a password, and secret JWT key.
 
 **Vue API key:** Generate an API key to add to request headers made by the Nuxt front end.
 

--- a/components/Auth0Login.vue
+++ b/components/Auth0Login.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="flex flex-col items-center justify-center h-screen">
+      <button class="px-4 py-2 mb-4 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50" @click="login">Login with auth0</button>
+      <p v-if="errorMessage" class="text-red-500 text-xs italic">{{ errorMessage }}</p>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    data() {
+      return {
+        errorMessage: ""
+      };
+    },
+    beforeMount() {
+      if (this.$auth.loggedIn) {
+        this.$router.push('/');
+      }
+    },    
+    mounted() {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const error = hashParams.get('error');
+      const errorDescription = hashParams.get('error_description');
+  
+      if (error === 'access_denied') {
+        this.errorMessage = decodeURIComponent(errorDescription);
+      }
+    },
+    watch: {
+      '$auth.loggedIn'(loggedIn) {
+        if (loggedIn) {
+          this.$router.push('/');
+        }
+      }
+    },
+    methods: {
+      async login() {
+        await this.$auth.loginWith('auth0')
+      }
+    }
+  }
+  </script>

--- a/components/Auth0Login.vue
+++ b/components/Auth0Login.vue
@@ -1,42 +1,49 @@
 <template>
-    <div class="flex flex-col items-center justify-center h-screen">
-      <button class="px-4 py-2 mb-4 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50" @click="login">Login with auth0</button>
-      <p v-if="errorMessage" class="text-red-500 text-xs italic">{{ errorMessage }}</p>
-    </div>
-  </template>
-  
-  <script>
-  export default {
-    data() {
-      return {
-        errorMessage: ""
-      };
-    },
-    beforeMount() {
-      if (this.$auth.loggedIn) {
-        this.$router.push('/');
-      }
-    },    
-    mounted() {
-      const hashParams = new URLSearchParams(window.location.hash.substring(1));
-      const error = hashParams.get('error');
-      const errorDescription = hashParams.get('error_description');
-  
-      if (error === 'access_denied') {
-        this.errorMessage = decodeURIComponent(errorDescription);
-      }
-    },
-    watch: {
-      '$auth.loggedIn'(loggedIn) {
-        if (loggedIn) {
-          this.$router.push('/');
-        }
-      }
-    },
-    methods: {
-      async login() {
-        await this.$auth.loginWith('auth0')
-      }
+  <div class="flex flex-col items-center justify-center h-screen">
+    <button
+      class="px-4 py-2 mb-4 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50"
+      @click="login"
+    >
+      Login with auth0
+    </button>
+    <p v-if="errorMessage" class="text-red-500 text-xs italic">
+      {{ errorMessage }}
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      errorMessage: "",
+    };
+  },
+  beforeMount() {
+    if (this.$auth.loggedIn) {
+      this.$router.push("/");
     }
-  }
-  </script>
+  },
+  mounted() {
+    const hashParams = new URLSearchParams(window.location.hash.substring(1));
+    const error = hashParams.get("error");
+    const errorDescription = hashParams.get("error_description");
+
+    if (error === "access_denied") {
+      this.errorMessage = decodeURIComponent(errorDescription);
+    }
+  },
+  watch: {
+    "$auth.loggedIn"(loggedIn) {
+      if (loggedIn) {
+        this.$router.push("/");
+      }
+    },
+  },
+  methods: {
+    async login() {
+      await this.$auth.loginWith("auth0");
+    },
+  },
+};
+</script>

--- a/components/PasswordLogin.vue
+++ b/components/PasswordLogin.vue
@@ -27,24 +27,27 @@
     },
     methods: {
       async login() {
-        try {
-          await this.$auth.loginWith('local', {
-            data: {
-              password: this.password
-            }
-          })
-          this.$router.push('/map')
-        } catch (error) {
-          if (error.response) {
-            if (error.response.status === 403) {
-              this.error = 'The password you entered is incorrect.';
-            } else if (error.response.data && error.response.data.message) {
-              this.error = error.response.data.message;
+        const authStrategy = this.$config.authStrategy || 'none';
+        if (authStrategy === 'password') {
+          try {
+            await this.$auth.loginWith('password', {
+              data: {
+                password: this.password
+              }
+            })
+            this.$router.push('/')
+          } catch (error) {
+            if (error.response) {
+              if (error.response.status === 403) {
+                this.error = 'The password you entered is incorrect.';
+              } else if (error.response.data && error.response.data.message) {
+                this.error = error.response.data.message;
+              } else {
+                this.error = 'An error occurred while trying to log in.';
+              }
             } else {
-              this.error = 'An error occurred while trying to log in.';
+              this.error = error.message || 'An error occurred while trying to log in.';
             }
-          } else {
-            this.error = error.message || 'An error occurred while trying to log in.';
           }
         }
       }
@@ -52,7 +55,7 @@
     watch: {
       '$auth.loggedIn'(loggedIn) {
         if (loggedIn) {
-          this.$router.push('/map');
+          this.$router.push('/');
         }
       }
     },
@@ -76,7 +79,7 @@
     },
     beforeMount() {
       if (this.$auth.loggedIn) {
-        this.$router.push('/map');
+        this.$router.push('/');
       }
     }
   }

--- a/components/PasswordLogin.vue
+++ b/components/PasswordLogin.vue
@@ -1,86 +1,104 @@
 <template>
-    <div class="flex flex-col items-center justify-center min-h-screen bg-gray-100">
-      <form @submit.prevent="login" class="w-full max-w-sm bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-        <div class="mb-4">
-          <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
-            Password
-          </label>
-          <input class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="password" type="password" v-model="password" required>
-        </div>
-        <div class="flex items-center justify-between">
-          <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="submit">
-            Login
-          </button>
-        </div>
-      </form>
-      <p v-if="error" class="text-red-500 text-xs italic">{{ error }}</p>
-    </div>
-  </template>
-  
-  <script>
-  export default {
-    data() {
-      return {
-        password: '',
-        error: null
-      }
-    },
-    methods: {
-      async login() {
-        const authStrategy = this.$config.authStrategy || 'none';
-        if (authStrategy === 'password') {
-          try {
-            await this.$auth.loginWith('password', {
-              data: {
-                password: this.password
-              }
-            })
-            this.$router.push('/')
-          } catch (error) {
-            if (error.response) {
-              if (error.response.status === 403) {
-                this.error = 'The password you entered is incorrect.';
-              } else if (error.response.data && error.response.data.message) {
-                this.error = error.response.data.message;
-              } else {
-                this.error = 'An error occurred while trying to log in.';
-              }
-            } else {
-              this.error = error.message || 'An error occurred while trying to log in.';
-            }
-          }
-        }
-      }
-    },
-    watch: {
-      '$auth.loggedIn'(loggedIn) {
-        if (loggedIn) {
-          this.$router.push('/');
-        }
-      }
-    },
-    async created() {
-      if (this.$route.query.secret_key) {
+  <div
+    class="flex flex-col items-center justify-center min-h-screen bg-gray-100"
+  >
+    <form
+      @submit.prevent="login"
+      class="w-full max-w-sm bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"
+    >
+      <div class="mb-4">
+        <label
+          class="block text-gray-700 text-sm font-bold mb-2"
+          for="password"
+        >
+          Password
+        </label>
+        <input
+          class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          id="password"
+          type="password"
+          v-model="password"
+          required
+        />
+      </div>
+      <div class="flex items-center justify-between">
+        <button
+          class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          type="submit"
+        >
+          Login
+        </button>
+      </div>
+    </form>
+    <p v-if="error" class="text-red-500 text-xs italic">{{ error }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      password: "",
+      error: null,
+    };
+  },
+  methods: {
+    async login() {
+      const authStrategy = this.$config.authStrategy || "none";
+      if (authStrategy === "password") {
         try {
-          const response = await this.$axios.$get('/api/login', {
-            params: {
-              secret_key: this.$route.query.secret_key
-            }
+          await this.$auth.loginWith("password", {
+            data: {
+              password: this.password,
+            },
           });
-          // If the request is successful, log in the user
-          if (response.token) {
-            this.$auth.strategy.token.set(`Bearer ${response.token}`);
-            location.reload();
-          }
+          this.$router.push("/");
         } catch (error) {
-          this.error = 'An error occurred while trying to log in.';
+          if (error.response) {
+            if (error.response.status === 403) {
+              this.error = "The password you entered is incorrect.";
+            } else if (error.response.data && error.response.data.message) {
+              this.error = error.response.data.message;
+            } else {
+              this.error = "An error occurred while trying to log in.";
+            }
+          } else {
+            this.error =
+              error.message || "An error occurred while trying to log in.";
+          }
         }
       }
     },
-    beforeMount() {
-      if (this.$auth.loggedIn) {
-        this.$router.push('/');
+  },
+  watch: {
+    "$auth.loggedIn"(loggedIn) {
+      if (loggedIn) {
+        this.$router.push("/");
+      }
+    },
+  },
+  async created() {
+    if (this.$route.query.secret_key) {
+      try {
+        const response = await this.$axios.$get("/api/login", {
+          params: {
+            secret_key: this.$route.query.secret_key,
+          },
+        });
+        // If the request is successful, log in the user
+        if (response.token) {
+          this.$auth.strategy.token.set(`Bearer ${response.token}`);
+          location.reload();
+        }
+      } catch (error) {
+        this.error = "An error occurred while trying to log in.";
       }
     }
-  }
-  </script>
+  },
+  beforeMount() {
+    if (this.$auth.loggedIn) {
+      this.$router.push("/");
+    }
+  },
+};
+</script>

--- a/middleware/authMiddleware.ts
+++ b/middleware/authMiddleware.ts
@@ -7,11 +7,10 @@ interface CustomContext extends Context {
 }
 
 const authMiddleware: Middleware = ({ app, $auth, redirect }) => {
-  const USE_PASSWORD = process.env.USE_PASSWORD ? process.env.USE_PASSWORD.replace(/['"]+/g, '') : 'NO';
-  if (USE_PASSWORD === 'NO') {
-    return;
-  }
-  if (!$auth.loggedIn || $auth.strategy.name !== 'auth0') {
+  const AUTH_STRATEGY = process.env.NUXT_ENV_AUTH_STRATEGY ? process.env.NUXT_ENV_AUTH_STRATEGY.replace(/['"]+/g, '') : 'none';
+  if (AUTH_STRATEGY === 'auth0' && (!$auth.loggedIn || $auth.strategy.name !== 'auth0')) {
+    return redirect('/login')
+  } else if (AUTH_STRATEGY === 'password' && (!$auth.loggedIn || $auth.strategy.name !== 'password')) {
     return redirect('/login')
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,11 +1,11 @@
 import { NuxtConfig } from '@nuxt/types'
 
+const authStrategy: string = process.env.NUXT_ENV_AUTH_STRATEGY?.replace(/['"]+/g, '') || 'none';
 const auth0Domain: string = process.env.NUXT_ENV_AUTH0_DOMAIN?.replace(/['"]+/g, '') || '';
 const auth0ClientId: string = process.env.NUXT_ENV_AUTH0_CLIENT_ID?.replace(/['"]+/g, '') || '';
 const auth0Audience: string = process.env.NUXT_ENV_AUTH0_AUDIENCE?.replace(/['"]+/g, '') || '';
 
 let tablesConfig = {};
-
 try {
     // Parse NUXT_ENV_VIEWS_CONFIG environment variable into a JSON object
     tablesConfig = JSON.parse(process.env.NUXT_ENV_VIEWS_CONFIG?.replace(/'/g, '') || '{}');
@@ -71,10 +71,16 @@ const config: NuxtConfig = {
 
   auth: {
     strategies: {
+      none: {
+        scheme: 'local',
+        tokenRequired: false,
+        tokenType: false
+      },
       auth0: {
         scheme: '~src/runtimeConfigurableScheme.ts'
       },
-      local: {
+      password: {
+        scheme: 'local',
         token: {
           property: 'token',
           required: true,
@@ -115,6 +121,7 @@ const config: NuxtConfig = {
       }
     },
     apiKey: process.env.VUE_APP_API_KEY,
+    authStrategy,
     tablesConfig,
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,17 @@
 <template>
   <div class="container">
     <h1>Available Views</h1>
-    <div v-for="(config, tableName) in tablesConfig" :key="tableName" class="table-item">
+    <div
+      v-for="(config, tableName) in tablesConfig"
+      :key="tableName"
+      class="table-item"
+    >
       <h2><strong>Table:</strong> {{ tableName }}</h2>
       <ul>
         <li v-for="view in config.VIEWS.split(',')" :key="view">
-          <nuxt-link :to="`/${view}/${tableName}`">{{ formatViewName(view) }}</nuxt-link>
+          <nuxt-link :to="`/${view}/${tableName}`">{{
+            formatViewName(view)
+          }}</nuxt-link>
         </li>
       </ul>
     </div>
@@ -16,21 +22,24 @@
 export default {
   data() {
     return {
-      tablesConfig: []
+      tablesConfig: [],
     };
   },
-    async mounted() {
-      try {
-        this.tablesConfig = this.$config.tablesConfig;
-      } catch (error) {
-      console.error('Error fetching table config on client side:', error);
+  async mounted() {
+    try {
+      this.tablesConfig = this.$config.tablesConfig;
+    } catch (error) {
+      console.error("Error fetching table config on client side:", error);
     }
   },
   methods: {
     formatViewName(view) {
-      return view.charAt(0).toUpperCase() + view.slice(1).toLowerCase().replace(/_/g, ' ');
-    }
-  }
+      return (
+        view.charAt(0).toUpperCase() +
+        view.slice(1).toLowerCase().replace(/_/g, " ")
+      );
+    },
+  },
 };
 </script>
 
@@ -72,7 +81,7 @@ export default {
 }
 
 .table-item ul li a {
-  color: #007BFF;
+  color: #007bff;
   text-decoration: none;
 }
 

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,45 +1,48 @@
 <template>
-    <component :is="loginComponent" />
+  <component :is="loginComponent" />
 </template>
-  
-  <script>
-  import PasswordLogin from '~/components/PasswordLogin.vue'
-  import Auth0Login from '~/components/Auth0Login.vue'
-  
-  export default {
-    data() {
-      return {
-        errorMessage: "",
-        authStrategy: 'none'
-      };
-    },
-    async mounted() {
-      try {
-        this.authStrategy = this.$config.authStrategy;
-      } catch (error) {
-        console.error("Error fetching authStrategy config on client side:", error);
-      }
-    },
-    components: {
-      PasswordLogin,
-      Auth0Login
-    },
-    computed: {
-      loginComponent() {
-        return this.authStrategy === 'auth0' ? 'Auth0Login' : 'PasswordLogin';
-      }
-    },
-    beforeMount() {
-      if (this.$auth.loggedIn || this.authStrategy === 'none') {
-        this.$router.push('/');
-      }
-    },    
-    watch: {
-      '$auth.loggedIn'(loggedIn) {
-        if (loggedIn) {
-          this.$router.push('/');
-        }
-      }
+
+<script>
+import PasswordLogin from "~/components/PasswordLogin.vue";
+import Auth0Login from "~/components/Auth0Login.vue";
+
+export default {
+  data() {
+    return {
+      errorMessage: "",
+      authStrategy: "none",
+    };
+  },
+  async mounted() {
+    try {
+      this.authStrategy = this.$config.authStrategy;
+    } catch (error) {
+      console.error(
+        "Error fetching authStrategy config on client side:",
+        error
+      );
     }
-  }
-  </script>
+  },
+  components: {
+    PasswordLogin,
+    Auth0Login,
+  },
+  computed: {
+    loginComponent() {
+      return this.authStrategy === "auth0" ? "Auth0Login" : "PasswordLogin";
+    },
+  },
+  beforeMount() {
+    if (this.$auth.loggedIn || this.authStrategy === "none") {
+      this.$router.push("/");
+    }
+  },
+  watch: {
+    "$auth.loggedIn"(loggedIn) {
+      if (loggedIn) {
+        this.$router.push("/");
+      }
+    },
+  },
+};
+</script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,50 +1,43 @@
 <template>
-    <!-- <Login /> -->
-    <div class="flex flex-col items-center justify-center h-screen">
-      <button class="px-4 py-2 mb-4 bg-blue-500 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-opacity-50" @click="loginWithAuth0">Login with Auth0</button>
-      <p v-if="errorMessage" class="text-red-500 text-xs italic">{{ errorMessage }}</p>
-    </div>
+    <component :is="loginComponent" />
 </template>
   
   <script>
-  // import Login from '~/components/Login.vue'
+  import PasswordLogin from '~/components/PasswordLogin.vue'
+  import Auth0Login from '~/components/Auth0Login.vue'
   
   export default {
     data() {
       return {
-        errorMessage: ""
+        errorMessage: "",
+        authStrategy: 'none'
       };
     },
+    async mounted() {
+      try {
+        this.authStrategy = this.$config.authStrategy;
+      } catch (error) {
+        console.error("Error fetching authStrategy config on client side:", error);
+      }
+    },
     components: {
-      // Login
+      PasswordLogin,
+      Auth0Login
+    },
+    computed: {
+      loginComponent() {
+        return this.authStrategy === 'auth0' ? 'Auth0Login' : 'PasswordLogin';
+      }
     },
     beforeMount() {
-      if (this.$auth.loggedIn) {
+      if (this.$auth.loggedIn || this.authStrategy === 'none') {
         this.$router.push('/');
       }
     },    
-    mounted() {
-      const hashParams = new URLSearchParams(window.location.hash.substring(1));
-      const error = hashParams.get('error');
-      const errorDescription = hashParams.get('error_description');
-
-      if (error === 'access_denied') {
-        this.errorMessage = decodeURIComponent(errorDescription);
-      }
-    },
     watch: {
       '$auth.loggedIn'(loggedIn) {
         if (loggedIn) {
           this.$router.push('/');
-        }
-      }
-    },
-    methods: {
-      async loginWithAuth0() {
-        try {
-          await this.$auth.loginWith('auth0')
-        } catch (error) {
-          console.error(error)
         }
       }
     }


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/guardianconnector-views/issues/15.

This PR is ironing out some past work to support different authentication methods: password with JWT, and auth0.

Instead of supporting one over the other wholesale, we are instead giving the administrator the option to define their authentication strategy: auth0, password, or none.

Depending on which strategy is chosen, the end user will have to log in via `Auth0Login.vue`, `PasswordLogin.vue`, or never have to log in (and be redirected away from the `/login` route if accessed) - respectively.

Authentication middleware has been adapted and streamlined in accordance to the requirements of the three strategies.