### PR TITLE
Create and structure `FeaturePopup` for alerts

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken';
 
 import setupDatabaseConnection from './utils/dbConnection';
 import fetchData from './utils/dbOperations';
-import { filterData, filterGeoData, filterDataByExtension, transformData, processGeoData, transformToGeojson } from './utils/dataProcessing';
+import { filterData, filterGeoData, filterDataByExtension, transformData, processGeoData, prepareChangeDetectionData, transformToGeojson } from './utils/dataProcessing';
 
 interface EnvVars {
   DATABASE: string;
@@ -245,8 +245,11 @@ if (!VIEWS_CONFIG) {
       app.get(`/${table}/alerts`, async (req: express.Request, res: express.Response) => {  try {
           // Fetch data
           const { mainData, columnsData } = await fetchData(db, table, IS_SQLITE);
+
+          const changeDetectionData = prepareChangeDetectionData(mainData);
+          
           // Convert data to GeoJSON format
-          const geojsonData = transformToGeojson(mainData);
+          const geojsonData = transformToGeojson(changeDetectionData);
 
           const response = {
             data: geojsonData, 

--- a/api/index.ts
+++ b/api/index.ts
@@ -39,6 +39,7 @@ interface ViewConfig {
   MAPBOX_PITCH: string;
   MAPBOX_BEARING: string;
   MAPBOX_3D: string;
+  LINK_TO_GCCD_RESOURCES: string;
   UNWANTED_COLUMNS?: string;
   UNWANTED_SUBSTRINGS?: string;
 }
@@ -246,7 +247,8 @@ if (!VIEWS_CONFIG) {
           // Fetch data
           const { mainData, columnsData } = await fetchData(db, table, IS_SQLITE);
 
-          const changeDetectionData = prepareChangeDetectionData(mainData);
+          // Prepare change detection data for the alerts view
+          const changeDetectionData = prepareChangeDetectionData(mainData, VIEWS[table].EMBED_MEDIA === "YES", VIEWS[table].LINK_TO_GCCD_RESOURCES === "YES");
           
           // Convert data to GeoJSON format
           const geojsonData = transformToGeojson(changeDetectionData);
@@ -255,6 +257,7 @@ if (!VIEWS_CONFIG) {
             data: geojsonData, 
             table: table,
             embedMedia: VIEWS[table].EMBED_MEDIA === "YES",
+            imageExtensions: imageExtensions, 
             mediaBasePath: VIEWS[table].MEDIA_BASE_PATH,
             mapboxAccessToken: MAPBOX_ACCESS_TOKEN, 
             mapboxStyle: VIEWS[table].MAPBOX_STYLE, 

--- a/api/utils/dataProcessing.ts
+++ b/api/utils/dataProcessing.ts
@@ -13,6 +13,10 @@ const filterColumns = (
   );
 };
 
+// Remove underscores from keys
+const removeUnderscores = (key: string): string => {
+  return key.replace(/^_/, "");
+};
 
 // Rewrite keys to be more legible
 const transformKey = (key: string): string => {
@@ -271,6 +275,21 @@ const processGeoData = (transformedData: Array<Record<string, any>>, filterField
   return processedGeoData;
 }
 
+const prepareChangeDetectionData = (data: Array<Record<string, any>>): Array<Record<string, any>> => {
+  const changeDetectionData = data.map((item) => {
+    const transformedItem: Record<string, any> = {};
+    Object.entries(item).forEach(([key, value]) => {
+      let transformedKey = removeUnderscores(key);
+      if (transformedKey === "topic") {
+        transformedKey = "source";
+      }
+      transformedItem[transformedKey] = value;
+    });
+    return transformedItem;
+  });
+  return changeDetectionData;
+}
+
 const transformToGeojson = (inputArray: Array<{ [key: string]: any }>): { 
   type: string; 
   features: Array<{ 
@@ -309,4 +328,4 @@ const transformToGeojson = (inputArray: Array<{ [key: string]: any }>): {
 };
 
 
-export { filterData, filterGeoData, filterDataByExtension, transformData, processGeoData, transformToGeojson };
+export { filterData, filterGeoData, filterDataByExtension, transformData, processGeoData, prepareChangeDetectionData, transformToGeojson };

--- a/api/utils/dataProcessing.ts
+++ b/api/utils/dataProcessing.ts
@@ -13,11 +13,6 @@ const filterColumns = (
   );
 };
 
-// Remove underscores from keys
-const removeUnderscores = (key: string): string => {
-  return key.replace(/^_/, "");
-};
-
 // Rewrite keys to be more legible
 const transformKey = (key: string): string => {
   let transformedKey = key.replace(/^g__/, "Geo").replace(/^p__/, "").replace(/_/g, " ");  
@@ -55,6 +50,9 @@ const transformValue = (key: string, value: any): any => {
   return transformedValue;
 };
 
+const capitalizeFirstLetter = (string: string): string => {
+  return string.split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ');
+};
 
 // Filter data using SQL column mapping
 type Column = {
@@ -275,20 +273,43 @@ const processGeoData = (transformedData: Array<Record<string, any>>, filterField
   return processedGeoData;
 }
 
-const prepareChangeDetectionData = (data: Array<Record<string, any>>): Array<Record<string, any>> => {
+const prepareChangeDetectionData = (
+  data: Array<Record<string, any>>,
+  embedMedia: boolean,
+  linkToGCCDResources: boolean
+): Array<Record<string, any>> => {
   const changeDetectionData = data.map((item) => {
     const transformedItem: Record<string, any> = {};
-    Object.entries(item).forEach(([key, value]) => {
-      let transformedKey = removeUnderscores(key);
-      if (transformedKey === "topic") {
-        transformedKey = "source";
+
+    // Keep fields starting with 'g__'
+    Object.keys(item).forEach(key => {
+      if (key.startsWith('g__')) {
+        transformedItem[key] = item[key];
       }
-      transformedItem[transformedKey] = value;
     });
+
+    // Include only the transformed fields
+    transformedItem["Alert type"] = capitalizeFirstLetter(item.alert_type?.replace(/_/g, ' ') ?? '');
+    transformedItem["Alert area (hectares)"] = typeof item.area_alert_ha === 'number' ? item.area_alert_ha.toFixed(2) : item.area_alert_ha;
+    transformedItem["Month detected"] = `${item.month_detec}-${item.year_detec}`;
+    transformedItem["Satellite"] = item.satellite;
+    transformedItem["Territory"] = capitalizeFirstLetter(item.territory_name ?? '');
+    transformedItem["Alert ID"] = item._id;
+    transformedItem["Alert detection range"] = `${item.date_start_t1} to ${item.date_end_t1}`;
+
+    if (embedMedia) {
+      transformedItem["image_url"] = `alerts/${item.territory_id}/${item.year_detec}/${item.month_detec}/${item._id}/resources/output_t1.jpg`;
+    }
+
+    if (linkToGCCDResources) {
+      transformedItem["preview_link"] = `alerts/${item.territory_id}/${item.year_detec}/${item.month_detec}/${item._id}/output.html`;
+    }
+
     return transformedItem;
   });
+
   return changeDetectionData;
-}
+};
 
 const transformToGeojson = (inputArray: Array<{ [key: string]: any }>): { 
   type: string; 

--- a/components/Alerts.vue
+++ b/components/Alerts.vue
@@ -1,5 +1,10 @@
 <template>
   <div id="map">
+    <FeaturePopup
+      :show-sidebar="showSidebar"
+      :feature="selectedFeature"
+      @close="showSidebar = false"
+    />
   </div>
 </template>
   
@@ -25,6 +30,8 @@ export default {
   ],
   data() {
     return {
+      showSidebar: false,
+      selectedFeature: null,
     };
   },
   computed: {
@@ -36,8 +43,12 @@ export default {
   methods: {
     getFilePaths: getFilePaths,
 
-    addDataToMap() {
+    onFeatureClick(feature) {
+      this.selectedFeature = feature;
+      this.showSidebar = true;
+    },
 
+    addDataToMap() {
       const geoJsonSource = this.data;
 
       // Add the source to the map
@@ -94,7 +105,26 @@ export default {
           "line-color": "#FF0000",
           "line-width": 2,
         },
-      });     
+      });   
+      
+      // Add event listeners
+      [
+        "data-layer-point",
+        "data-layer-linestring",
+        "data-layer-polygon",
+      ].forEach((layerId) => {
+        this.map.on("mouseenter", layerId, () => {
+          this.map.getCanvas().style.cursor = "pointer";
+        });
+        this.map.on("mouseleave", layerId, () => {
+          this.map.getCanvas().style.cursor = "";
+        });
+        this.map.on("click", layerId, (e) => {
+          let featureObject = e.features[0].properties;
+          this.selectedFeature = featureObject;
+          this.showSidebar = true;
+        });
+      });
     }
   },
   mounted() {
@@ -144,5 +174,15 @@ body {
   top: 0;
   bottom: 0;
   width: 100%;
+}
+
+.mapboxgl-popup-content {
+  word-wrap: break-word;
+}
+
+.popup-media {
+  width: 100%;
+  display: block;
+  margin-top: 5px;
 }
 </style>

--- a/components/Alerts.vue
+++ b/components/Alerts.vue
@@ -1,8 +1,13 @@
 <template>
   <div id="map">
     <FeaturePopup
-      :show-sidebar="showSidebar"
+      :embed-media="embedMedia"
       :feature="selectedFeature"
+      :file-paths="imageUrl"
+      :image-extensions="imageExtensions"
+      :preview-map-link="previewMapLink"
+      :media-base-path="mediaBasePath"      
+      :show-sidebar="showSidebar"
       @close="showSidebar = false"
     />
   </div>
@@ -10,13 +15,13 @@
   
 <script>
 import mapboxgl from "mapbox-gl";
-import getFilePaths from "@/src/utils.ts";
 
 export default {
   components: { },
   props: [
     "data",
     "embedMedia",
+    "imageExtensions",
     "mediaBasePath",
     "mapboxAccessToken",
     "mapboxStyle",
@@ -26,25 +31,23 @@ export default {
     "mapboxZoom",
     "mapboxPitch",
     "mapboxBearing",
-    "mapbox3d",
+    "mapbox3d"
   ],
   data() {
     return {
       showSidebar: false,
       selectedFeature: null,
+      imageUrl: [],
+      previewMapLink: null
     };
   },
   computed: {
-    allExtensions() {
-      return [
-      ];
-    },
   },
   methods: {
-    getFilePaths: getFilePaths,
-
     onFeatureClick(feature) {
       this.selectedFeature = feature;
+      this.imageUrl = [feature.properties.image_url];
+      this.previewMapLink = [feature.properties.preview_link];
       this.showSidebar = true;
     },
 
@@ -121,6 +124,10 @@ export default {
         });
         this.map.on("click", layerId, (e) => {
           let featureObject = e.features[0].properties;
+          this.imageUrl = [e.features[0].properties.image_url];
+          this.previewMapLink = [e.features[0].properties.preview_link];
+          delete featureObject["image_url"];
+          delete featureObject["preview_link"];
           this.selectedFeature = featureObject;
           this.showSidebar = true;
         });

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -1,34 +1,42 @@
 <template>
-    <div class="feature p-4 rounded-lg shadow-lg">
-      <!-- Conditional rendering depending on file extension -->
-      <Media
-        v-if="embedMedia === true"
-        v-for="filePath in filePaths"
-        :key="filePath"
-        :mediaBasePath="mediaBasePath"
-        :filePath="filePath"
-        :image-extensions="imageExtensions"
-        :audio-extensions="audioExtensions"
-        :video-extensions="videoExtensions"
-      />
-      <div class="mt-4">
-        <div
-          v-for="(value, key) in sortedFeature"
-          :key="key"
-          v-if="
-            value !== null &&
-            value !== '' &&
-            key.toLowerCase() !== 'uuid' &&
-            !key.toLowerCase().includes('photo') &&
-            key.toLowerCase() !== 'audio'
-          "
-          class="mb-2"
-        >
-          <span class="font-bold">{{ key }}</span
-          >: <span>{{ value }}</span>
-        </div>
+  <div class="feature p-4 rounded-lg shadow-lg">
+    <!-- Conditional rendering depending on file extension -->
+    <Media
+      v-if="embedMedia === true"
+      v-for="filePath in filePaths"
+      :key="filePath"
+      :mediaBasePath="mediaBasePath"
+      :filePath="filePath"
+      :image-extensions="imageExtensions"
+      :audio-extensions="audioExtensions"
+      :video-extensions="videoExtensions"
+    />
+    <div class="mt-4">
+      <div
+        v-for="(value, key) in sortedFeature"
+        :key="key"
+        v-if="
+          value !== null &&
+          value !== '' &&
+          key.toLowerCase() !== 'uuid' &&
+          !key.toLowerCase().includes('photo') &&
+          key.toLowerCase() !== 'audio'
+        "
+        class="mb-2"
+      >
+        <span class="font-bold">{{ key }}</span
+        >: <span>{{ value }}</span>
       </div>
+      <span v-if="previewMapLink !== false ">
+            <a
+              class="text-blue-500 hover:text-blue-700"
+              :href="mediaBasePath + '/' + previewMapLink + '?inline=true'"
+              target="_blank"
+              >Preview Map (not working yet)</a
+            >
+          </span>
     </div>
+  </div>
 </template>
 
 <script>
@@ -48,6 +56,7 @@ export default {
   },
   props: [
     "embedMedia",
+    "previewMapLink",
     "mediaBasePath",
     "filePaths",
     "feature",

--- a/components/FeaturePopup.vue
+++ b/components/FeaturePopup.vue
@@ -3,6 +3,7 @@
     <button class="close-btn" @click="$emit('close')">X</button>
     <Feature
       :embed-media="embedMedia"
+      :preview-map-link="previewMapLink"
       :mediaBasePath="mediaBasePath"
       :filePaths="filePaths"
       :feature="filteredFeature"
@@ -20,6 +21,7 @@ export default {
   components: { Feature },
   props: [
     "embedMedia",
+    "previewMapLink",
     "mediaBasePath",
     "filePaths",
     "feature",

--- a/components/Gallery.vue
+++ b/components/Gallery.vue
@@ -15,9 +15,9 @@
       v-for="(feature, index) in paginatedData"
       :key="index"
       :embed-media="embedMedia"
-      :media-base-path="mediaBasePath"
-      :file-paths="getFilePaths(feature, allExtensions)"
+      :file-paths="getFilePathsWithExtension(feature, allExtensions)"
       :feature="feature"
+      :media-base-path="mediaBasePath"
       :image-extensions="imageExtensions"
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
@@ -28,7 +28,7 @@
 <script>
 import Feature from "@/components/Feature.vue";
 import DataFilter from "@/components/DataFilter.vue";
-import getFilePaths from "@/src/utils.ts";
+import getFilePathsWithExtension from "@/src/utils.ts";
 
 export default {
   components: { Feature, DataFilter },
@@ -75,7 +75,7 @@ export default {
         this.currentPage++;
       }
     },
-    getFilePaths: getFilePaths,
+    getFilePathsWithExtension: getFilePathsWithExtension,
     filter(values) {
       if (values.includes("null")) {
         this.filteredData = this.data;

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -8,13 +8,13 @@
       @filter="filter"
     />
     <FeaturePopup
-      :show-sidebar="showSidebar"
       :embed-media="embedMedia"
       :media-base-path="mediaBasePath"
-      :file-paths="getFilePaths(selectedFeature, allExtensions)"
+      :file-paths="getFilePathsWithExtension(selectedFeature, allExtensions)"
       :feature="selectedFeature"
-      :image-extensions="imageExtensions"
+      :show-sidebar="showSidebar"
       :audio-extensions="audioExtensions"
+      :image-extensions="imageExtensions"
       :video-extensions="videoExtensions"
       @close="showSidebar = false"
     />
@@ -25,7 +25,7 @@
 import mapboxgl from "mapbox-gl";
 import DataFilter from "@/components/DataFilter.vue";
 import FeaturePopup from "@/components/FeaturePopup.vue";
-import getFilePaths from "@/src/utils.ts";
+import getFilePathsWithExtension from "@/src/utils.ts";
 
 export default {
   components: { DataFilter, FeaturePopup },
@@ -78,7 +78,7 @@ export default {
       this.addDataToMap(); // Call this method to update the map data
     },
 
-    getFilePaths: getFilePaths,
+    getFilePathsWithExtension: getFilePathsWithExtension,
 
     onFeatureClick(feature) {
       this.selectedFeature = feature;

--- a/components/Media.vue
+++ b/components/Media.vue
@@ -47,21 +47,26 @@ export default {
   ],
   computed: {
     isImage() {
-      const extension = this.getExtension(this.filePath);
-      return this.imageExtensions.includes(extension);
+      return this.checkExtension(this.imageExtensions);
+
     },
     isAudio() {
-      const extension = this.getExtension(this.filePath);
-      return this.audioExtensions.includes(extension);
+      return this.checkExtension(this.audioExtensions);
+
     },
     isVideo() {
-      const extension = this.getExtension(this.filePath);
-      return this.videoExtensions.includes(extension);
+      return this.checkExtension(this.videoExtensions);
+
     },
   },
   methods: {
     getExtension(filePath) {
       return filePath.split(".").pop().toLowerCase();
+    },
+    checkExtension(extensions) {
+      if (!extensions) return false;
+      const extension = this.getExtension(this.filePath);
+      return extensions.includes(extension);
     },
   },
 };

--- a/pages/alerts/_tablename.vue
+++ b/pages/alerts/_tablename.vue
@@ -3,6 +3,7 @@
     <Alerts 
       v-if="dataFetched"
       :data="alertsData"
+      :image-extensions="imageExtensions"
       :embed-media="embedMedia"
       :media-base-path="mediaBasePath"
       :mapbox-access-token="mapboxAccessToken"
@@ -52,6 +53,7 @@ export default {
       return {
         dataFetched: true,
         alertsData: response.data,
+        imageExtensions: response.imageExtensions,
         embedMedia: response.embedMedia,
         mediaBasePath: response.mediaBasePath,
         mapboxAccessToken: response.mapboxAccessToken,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 // Function to get file paths from a feature object
-export default function getFilePaths(feature: {[key: string]: any}, allExtensions: string[]): string[] {  
+export default function getFilePathsWithExtension(feature: {[key: string]: any}, allExtensions: string[]): string[] {  
   if (!feature) return [];
 
   // Get the value of the uuidKey or set it to null if it doesn't exist


### PR DESCRIPTION
Checks one off the list on #16 by implementing the `FeaturePopup` component to show alert properties, links, and an embedded image for change detection alerts.

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/1dc7b383-ee20-40cb-8c5e-b07c7f286fe9)

* Modified the `alerts/` API endpoint to use a `prepareChangeDetectionData()` function to format the properties key/value pairs to more legible to humans, discarding the ones that are not useful to the end user, and depending on if the view has media embedding & linking to GCCD resources turned on, creates links to some of the assets for embedding or linking.
* Added event listeners for the alert map features (similar to how it's done in the `Map` component).
* In `Feature`, conditionally render GCCD preview map link if provided.
* Some other minor stylistic and naming fixes here and there.