### PR TITLE
Add dynamic color changes to features based on date and `SelectedFeature` state

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -251,7 +251,10 @@ if (!VIEWS_CONFIG) {
           const changeDetectionData = prepareChangeDetectionData(mainData, VIEWS[table].EMBED_MEDIA === "YES", VIEWS[table].LINK_TO_GCCD_RESOURCES === "YES");
           
           // Convert data to GeoJSON format
-          const geojsonData = transformToGeojson(changeDetectionData);
+          const geojsonData = {
+            mostRecentAlerts: transformToGeojson(changeDetectionData.mostRecentAlerts), 
+            otherAlerts: transformToGeojson(changeDetectionData.otherAlerts)
+          };
 
           const response = {
             data: geojsonData, 

--- a/api/utils/dataProcessing.ts
+++ b/api/utils/dataProcessing.ts
@@ -352,19 +352,24 @@ const transformToGeojson = (inputArray: Array<{ [key: string]: any }>): {
   type: string; 
   features: Array<{ 
     type: string; 
+    id?: string | undefined;
     properties: { [key: string]: any }; 
     geometry?: { [key: string]: any };
   }>;
 } => {
   const features = inputArray.map(input => {
     const feature = { 
-      type: "feature", 
+      type: "Feature", 
+      id: undefined,
       properties: {} as { [key: string]: any },
       geometry: {} as { [key: string]: any }
     };
 
     Object.entries(input).forEach(([key, value]) => {
-      if (key.startsWith("g__")) {
+      if (key === "Alert ID") {
+        feature.id = value.substring(4);
+        feature.properties[key] = value;
+      } else if (key.startsWith("g__")) {
         const geometryKey = key.substring(3); // Removes 'g__' prefix
         if (geometryKey === "coordinates") {
           feature.geometry[geometryKey] = JSON.parse(value);

--- a/api/utils/dataProcessing.ts
+++ b/api/utils/dataProcessing.ts
@@ -277,8 +277,24 @@ const prepareChangeDetectionData = (
   data: Array<Record<string, any>>,
   embedMedia: boolean,
   linkToGCCDResources: boolean
-): Array<Record<string, any>> => {
-  const changeDetectionData = data.map((item) => {
+): { mostRecentAlerts: Array<Record<string, any>>, otherAlerts: Array<Record<string, any>> } => {
+  let latestDate = new Date(0); // Initialize to a very early date
+  let latestMonthStr = '';
+
+  // Determine the most recent month
+  data.forEach(item => {
+    const monthYearStr = `${item.month_detec}-${item.year_detec}`;
+    const date = new Date(item.year_detec, item.month_detec - 1);
+    if (date > latestDate) {
+      latestDate = date;
+      latestMonthStr = monthYearStr;
+    }
+  });
+
+  const mostRecentAlerts: Array<Record<string, any>> = [];
+  const otherAlerts: Array<Record<string, any>> = [];
+
+  data.forEach((item) => {
     const transformedItem: Record<string, any> = {};
 
     // Keep fields starting with 'g__'
@@ -288,27 +304,48 @@ const prepareChangeDetectionData = (
       }
     });
 
+    // To rewrite the satellite prefix field
+    const satelliteLookup: { [key: string]: string } = {
+      "S1": "Sentinel-1",
+      "S2": "Sentinel-2",
+      "PS": "Planetscope",
+      "L8": "Landsat 8",
+      "L9": "Landsat 9",
+      "WV1": "WorldView-1",
+      "WV2": "WorldView-2",
+      "WV3": "WorldView-3",
+      "WV4": "WorldView-4",
+      "IK": "IKONOS",
+    };
+
     // Include only the transformed fields
     transformedItem["Alert type"] = capitalizeFirstLetter(item.alert_type?.replace(/_/g, ' ') ?? '');
     transformedItem["Alert area (hectares)"] = typeof item.area_alert_ha === 'number' ? item.area_alert_ha.toFixed(2) : item.area_alert_ha;
     transformedItem["Month detected"] = `${item.month_detec}-${item.year_detec}`;
-    transformedItem["Satellite"] = item.satellite;
+    transformedItem["Satellite used for detection"] = satelliteLookup[item.sat_detect_prefix] || item.sat_detect_prefix;
     transformedItem["Territory"] = capitalizeFirstLetter(item.territory_name ?? '');
     transformedItem["Alert ID"] = item._id;
     transformedItem["Alert detection range"] = `${item.date_start_t1} to ${item.date_end_t1}`;
 
     if (embedMedia) {
       transformedItem["image_url"] = `alerts/${item.territory_id}/${item.year_detec}/${item.month_detec}/${item._id}/resources/output_t1.jpg`;
+      transformedItem["image_caption"] = satelliteLookup[item.sat_viz_prefix] || item.sat_viz_prefix;
     }
-
     if (linkToGCCDResources) {
       transformedItem["preview_link"] = `alerts/${item.territory_id}/${item.year_detec}/${item.month_detec}/${item._id}/output.html`;
     }
 
-    return transformedItem;
+    transformedItem["Month detected"] = `${item.month_detec}-${item.year_detec}`;
+
+    // Segregate data based on the latest month detected
+    if (transformedItem["Month detected"] === latestMonthStr) {
+      mostRecentAlerts.push(transformedItem);
+    } else {
+      otherAlerts.push(transformedItem);
+    }
   });
 
-  return changeDetectionData;
+  return { mostRecentAlerts, otherAlerts };
 };
 
 const transformToGeojson = (inputArray: Array<{ [key: string]: any }>): { 

--- a/components/Alerts.vue
+++ b/components/Alerts.vue
@@ -185,7 +185,7 @@ export default {
 
           // Fields that may or may not exist, depending on views config
           let imageUrl = featureObject.image_url;
-          imageUrl && (this.imageUrl = imageUrl);
+          imageUrl && (this.imageUrl = [imageUrl]);
           let imageCaption = featureObject.image_caption;
           imageCaption && (this.imageCaption = "Imagery source: " + imageCaption);
           let previewMapLink = featureObject.preview_link;

--- a/components/Alerts.vue
+++ b/components/Alerts.vue
@@ -9,7 +9,7 @@
       :preview-map-link="previewMapLink"
       :media-base-path="mediaBasePath"      
       :show-sidebar="showSidebar"
-      @close="showSidebar = false"
+      @close="resetSelectedFeature"
     />
   </div>
 </template>
@@ -38,6 +38,7 @@ export default {
     return {
       showSidebar: false,
       selectedFeature: null,
+      selectedFeatureId: null,
       imageUrl: [],
       imageCaption: null,
       previewMapLink: null
@@ -46,11 +47,26 @@ export default {
   computed: {
   },
   methods: {
+    resetSelectedFeature() {
+      if (this.selectedFeatureId) {
+        // Reset the feature state of the previously selected feature
+        this.map.queryRenderedFeatures({ layers: ["recent-alerts", "alerts"] }).forEach(feature => {
+          if (feature.properties["Alert ID"] === this.selectedFeatureId) {
+            this.map.setFeatureState(
+              { source: feature.source, id: feature.id },
+              { selected: false }
+            );
+          }
+        });
+
+        // Reset the component state
+        this.selectedFeatureId = null;
+        this.selectedFeature = null;
+        this.showSidebar = false;
+      }
+    },
     addDataToMap() {
       const geoJsonSource = this.data;
-
-      console.log(geoJsonSource)
-
 
       // Add the most recent alerts source to the map
       this.map.addSource("recent-alerts", {
@@ -72,8 +88,13 @@ export default {
         source: "recent-alerts",
         filter: ["==", "$type", "Polygon"],
         paint: {
-          "fill-color": "#EC00FF",
-          "fill-opacity": 0.5,
+          "fill-color": [
+            'case',
+              ['boolean', ['feature-state', 'selected'], false],
+              '#FFFF00',
+              '#EC00FF'
+            ],          
+            "fill-opacity": 0.5,
         },
       });     
       
@@ -84,7 +105,12 @@ export default {
         source: "recent-alerts",
         filter: ["==", "$type", "Polygon"],
         paint: {
-          "line-color": "#EC00FF",
+          "line-color": [
+            'case',
+              ['boolean', ['feature-state', 'selected'], false],
+              '#FFFF00',
+              '#EC00FF'
+          ],
           "line-width": 2,
         },
       });   
@@ -96,8 +122,13 @@ export default {
         source: "alerts",
         filter: ["==", "$type", "Polygon"],
         paint: {
-          "fill-color": "#FF0000",
-          "fill-opacity": 0.5,
+          "fill-color": [
+            'case',
+              ['boolean', ['feature-state', 'selected'], false],
+              '#FFFF00',
+              '#FF0000'
+          ],   
+            "fill-opacity": 0.5,
         },
       });     
       
@@ -108,7 +139,12 @@ export default {
         source: "alerts",
         filter: ["==", "$type", "Polygon"],
         paint: {
-          "line-color": "#FF0000",
+          "line-color": [
+            'case',
+              ['boolean', ['feature-state', 'selected'], false],
+              '#FFFF00',
+              '#FF0000'
+          ],  
           "line-width": 2,
         },
       });   
@@ -126,12 +162,38 @@ export default {
         });
         this.map.on("click", layerId, (e) => {
           let featureObject = e.features[0].properties;
-          this.imageUrl = [e.features[0].properties.image_url];
-          this.imageCaption = "Imagery source: " + e.features[0].properties.image_caption;
-          this.previewMapLink = [e.features[0].properties.preview_link];
-          delete featureObject["image_url"];
-          delete featureObject["image_caption"];
-          delete featureObject["preview_link"];
+          let featureId = featureObject["Alert ID"];
+
+          // Check if there is a previously selected feature
+          if (this.selectedFeatureId) {
+            // Find the previously selected feature and reset its style
+            this.map.queryRenderedFeatures({ layers: [layerId] }).forEach(feature => {
+              if (feature.properties["Alert ID"] === this.selectedFeatureId) {
+                this.map.setFeatureState(
+                  { source: layerId, id: feature.id },
+                  { selected: false }
+                );
+              }
+            });
+          }
+
+          // Set new feature state
+          this.map.setFeatureState(
+            { source: layerId, id: e.features[0].id },
+            { selected: true }
+          );
+
+          // Fields that may or may not exist, depending on views config
+          let imageUrl = featureObject.image_url;
+          imageUrl && (this.imageUrl = imageUrl);
+          let imageCaption = featureObject.image_caption;
+          imageCaption && (this.imageCaption = "Imagery source: " + imageCaption);
+          let previewMapLink = featureObject.preview_link;
+          previewMapLink && (this.previewMapLink = previewMapLink);
+          delete featureObject["image_url"], delete featureObject["image_caption"], delete featureObject["preview_link"];
+
+          // Update component state
+          this.selectedFeatureId = featureId;
           this.selectedFeature = featureObject;
           this.showSidebar = true;
         });
@@ -164,7 +226,22 @@ export default {
       }
 
       this.addDataToMap();
-    });
+
+      // Navigation Control (zoom buttons and compass)
+      const nav = new mapboxgl.NavigationControl();
+      this.map.addControl(nav, 'top-right');
+
+      // Scale Control
+      const scale = new mapboxgl.ScaleControl({
+        maxWidth: 80,
+        unit: 'metric'
+      });
+      this.map.addControl(scale, 'bottom-left');
+
+      // Fullscreen Control
+      const fullscreenControl = new mapboxgl.FullscreenControl();
+      this.map.addControl(fullscreenControl, 'top-right');
+      });
   },
   beforeDestroy() {
     if (this.map) {

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -7,6 +7,7 @@
       :key="filePath"
       :mediaBasePath="mediaBasePath"
       :filePath="filePath"
+      :image-caption="imageCaption"
       :image-extensions="imageExtensions"
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
@@ -60,6 +61,7 @@ export default {
     "mediaBasePath",
     "filePaths",
     "feature",
+    "imageCaption",
     "imageExtensions",
     "audioExtensions",
     "videoExtensions",

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -28,7 +28,7 @@
         <span class="font-bold">{{ key }}</span
         >: <span>{{ value }}</span>
       </div>
-      <span v-if="previewMapLink !== false ">
+      <span v-if="previewMapLink !== null ">
             <a
               class="text-blue-500 hover:text-blue-700"
               :href="mediaBasePath + '/' + previewMapLink + '?inline=true'"

--- a/components/FeaturePopup.vue
+++ b/components/FeaturePopup.vue
@@ -7,6 +7,7 @@
       :mediaBasePath="mediaBasePath"
       :filePaths="filePaths"
       :feature="filteredFeature"
+      :image-caption="imageCaption"
       :image-extensions="imageExtensions"
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
@@ -25,6 +26,7 @@ export default {
     "mediaBasePath",
     "filePaths",
     "feature",
+    "imageCaption",
     "imageExtensions",
     "audioExtensions",
     "videoExtensions",

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -80,11 +80,6 @@ export default {
 
     getFilePathsWithExtension: getFilePathsWithExtension,
 
-    onFeatureClick(feature) {
-      this.selectedFeature = feature;
-      this.showSidebar = true;
-    },
-
     addDataToMap() {
       // Remove existing data layers from the map
       if (this.map) {
@@ -209,6 +204,21 @@ export default {
       }
 
       this.addDataToMap();
+
+      // Navigation Control (zoom buttons and compass)
+      const nav = new mapboxgl.NavigationControl();
+      this.map.addControl(nav, 'bottom-right');
+
+      // Scale Control
+      const scale = new mapboxgl.ScaleControl({
+        maxWidth: 80,
+        unit: 'metric'
+      });
+      this.map.addControl(scale, 'bottom-left');
+
+      // Fullscreen Control
+      const fullscreenControl = new mapboxgl.FullscreenControl();
+      this.map.addControl(fullscreenControl, 'bottom-right')
     });
   },
   beforeDestroy() {

--- a/components/Media.vue
+++ b/components/Media.vue
@@ -13,6 +13,7 @@
           class="w-full h-auto rounded-lg"
           loading="lazy"
         />
+        <span v-if="imageCaption !== false "><center><em>{{ imageCaption }}</em></center></span>
       </a>
     </div>
     <div v-if="isAudio" class="mb-4">
@@ -41,6 +42,7 @@ export default {
   props: [
     "mediaBasePath",
     "filePath",
+    "imageCaption",
     "imageExtensions",
     "audioExtensions",
     "videoExtensions",


### PR DESCRIPTION
Contributes to https://github.com/ConservationMetrics/guardianconnector-views/issues/16 by contributing the following:

* The API endpoint for alerts now provides two GeoJSON arrays, `mostRecentAlerts` and `otherAlerts` based on the date given in the data, so as to be able to style the most recent alerts differently from the others.
* `selectedFeature` state management has been expanded to store the ID and source of the layer, to be able to highlight a feature with a different color when clicked (selected), and returned back to the original color when deselected (by closing the `FeaturePopup` or clicking another feature).
* Ideally should have been a different PR but -- Added image captions for the `sat_viz_detec` T1 JPG image used in the `FeaturePopup` with a lookup table of commonly used satellites, fallback to acronym given as a value.
* Implemented Mapbox map controls.