### PR TITLE
Add download all alerts buttons to `AlertsIntroPanel`

### DIFF
--- a/components/Alerts.vue
+++ b/components/Alerts.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="map">
     <FeaturePopup
+      :all-data-geojson="data"
       :embed-media="embedMedia"
       :feature="selectedFeature"
       :feature-geojson="selectedFeatureGeojson"
@@ -11,7 +12,7 @@
       :media-base-path="mediaBasePath"      
       :show-sidebar="showSidebar"
       :show-intro-panel="showIntroPanel"
-      :show-download-buttons="showDownloadButtons"
+      :download-alert="downloadAlert"
       :statistics="statistics"
       @close="resetSelectedFeature"
     />
@@ -45,7 +46,7 @@ export default {
     return {
       showSidebar: true,
       showIntroPanel: true,
-      showDownloadButtons: false,
+      downloadAlert: false,
       selectedFeature: null,
       selectedFeatureGeojson: null,
       selectedFeatureId: null,
@@ -284,7 +285,7 @@ export default {
           this.selectedFeatureSource = layerId;
           this.showSidebar = true;
           this.showIntroPanel = false;
-          this.showDownloadButtons = true;
+          this.downloadAlert = true;
 
           // Fields that may or may not exist, depending on views config
           let imageUrl = featureObject.image_url;

--- a/components/AlertsIntroPanel.vue
+++ b/components/AlertsIntroPanel.vue
@@ -53,10 +53,18 @@
         <p class="mb-2"><em>Note: this chart is showing data since {{ statistics.recentAlertsDate }}</em></p>
       </div>
     </div>
+    <div class="p-4" v-if="allDataGeojson">
+      <h3 class="text-2xl font-semibold mb-2 text-center">Download all alerts</h3>
+      <Download 
+        :geojson="allDataGeojson" 
+        :type-of-data="'all'" 
+      />
+    </div>
   </div>
 </template>
 
 <script>
+import Download from "@/components/Download.vue";
 import { Line as LineChart } from "vue-chartjs";
 import { Chart, Title, Tooltip, Legend, LineElement, PointElement, CategoryScale, LinearScale } from 'chart.js';
 
@@ -64,9 +72,9 @@ Chart.register(Title, Tooltip, Legend, LineElement, PointElement, CategoryScale,
 
 
 export default {
-  props: ["statistics"],
+  props: ["statistics", "allDataGeojson"],
   name: "LineChartComponent",
-  components: { LineChart },
+  components: { Download, LineChart },
   computed: {
     chartData() {
         return {

--- a/components/Download.vue
+++ b/components/Download.vue
@@ -2,13 +2,15 @@
   <div class="button-container">
     <button
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mx-2"
-      @click="downloadCSV"
+      @click="typeOfData === 'alert' ? downloadAlertCSV() : downloadAllCSV()"
     >
       Download CSV
     </button>
     <button
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mx-2"
-      @click="downloadGeoJSON"
+      @click="
+        typeOfData === 'alert' ? downloadAlertGeoJSON() : downloadAllGeoJSON()
+      "
     >
       Download GeoJSON
     </button>
@@ -17,50 +19,53 @@
 
 <script>
 export default {
-  props: ["featureGeojson"],
+  props: ["geojson", "typeOfData"],
   methods: {
-    downloadCSV() {
+    downloadAlertCSV() {
       // Convert featureObject to CSV and download
-      if (!this.featureGeojson) {
-        console.error("No GeoJSON data available to download and convert to CSV.");
+      if (!this.geojson) {
+        console.error(
+          "No GeoJSON data available to download and convert to CSV."
+        );
         return;
       }
 
       // Flatten the object
-      const { geometry, properties } = this.featureGeojson;
+      const { geometry, properties } = this.geojson;
       let flattened = { ...properties }; // Start with properties
-      
+
       // Ensure that all coordinate properties render well in CSV
-      flattened['Geographic centroid'] = `[${properties['Geographic centroid']}]`;
+      flattened[
+        "Geographic centroid"
+      ] = `[${properties["Geographic centroid"]}]`;
       const coordinates = JSON.stringify(geometry.coordinates);
-      delete flattened['coordinates'];
-      
+      delete flattened["coordinates"];
+
       // Generate CSV data
       const csvColumns = Object.keys(flattened);
-      const csvData = Object.values(flattened).map(value => 
-        typeof value === 'string' && value.includes(',') ? `"${value.replace(/"/g, '""')}"` : value
+      const csvData = Object.values(flattened).map((value) =>
+        typeof value === "string" && value.includes(",")
+          ? `"${value.replace(/"/g, '""')}"`
+          : value
       );
 
       // Remove top level GeoJSON "type" property
-      const typeIndex = csvColumns.indexOf('type');
+      const typeIndex = csvColumns.indexOf("type");
       if (typeIndex > -1) {
         csvColumns.splice(typeIndex, 1);
         csvData.splice(typeIndex, 1);
       }
 
       // Append geometry type and coordinates at the end
-      csvColumns.push('type');
+      csvColumns.push("type");
       csvData.push(`"${geometry.type}"`);
-      csvColumns.push('coordinates');
+      csvColumns.push("coordinates");
       csvData.push(`"${coordinates}"`);
 
-      const csvString = [
-        csvColumns.join(','),
-        csvData.join(',')
-      ].join('\n');
+      const csvString = [csvColumns.join(","), csvData.join(",")].join("\n");
 
       // Download CSV
-      const filename = `${this.featureGeojson.properties["Alert ID"]}.csv`;
+      const filename = `${this.geojson.properties["Alert ID"]}.csv`;
       const blob = new Blob([csvString], { type: "text/csv" });
 
       const link = document.createElement("a");
@@ -74,17 +79,132 @@ export default {
       document.body.removeChild(link);
       URL.revokeObjectURL(link.href);
     },
-    downloadGeoJSON() {
+    downloadAlertGeoJSON() {
       // Convert featureObject to GeoJSON and download
-      if (!this.featureGeojson) {
+      if (!this.geojson) {
         console.error("No GeoJSON data available to download.");
         return;
       }
 
-      const filename = `${this.featureGeojson.properties["Alert ID"]}.geojson`;
-      const jsonStr = JSON.stringify(this.featureGeojson, null, 2);
+      const filename = `${this.geojson.properties["Alert ID"]}.geojson`;
+      const jsonStr = JSON.stringify(this.geojson, null, 2);
       const blob = new Blob([jsonStr], { type: "application/json" });
 
+      const link = document.createElement("a");
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      document.body.appendChild(link);
+
+      link.click();
+
+      // Clean up and free memory
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+    },
+    downloadAllCSV() {
+      if (
+        !this.geojson ||
+        !this.geojson.mostRecentAlerts ||
+        !this.geojson.otherAlerts
+      ) {
+        console.error("No complete GeoJSON data available to download as CSV.");
+        return;
+      }
+
+      // Combine features from mostRecentAlerts and otherAlerts
+      const combinedFeatures = [
+        ...this.geojson.otherAlerts.features,
+        ...this.geojson.mostRecentAlerts.features,
+      ];
+
+      // Prepare CSV data
+      let csvString = "";
+      let headerWritten = false;
+
+      combinedFeatures.forEach((feature) => {
+        const { geometry, properties } = feature;
+
+        // Flatten the object
+        let flattened = { ...properties };
+        delete flattened['image_url'];
+        delete flattened['image_caption'];
+        delete flattened['preview_link'];
+
+        // Handle coordinates and other properties that need special formatting
+        const coordinates = JSON.stringify(geometry.coordinates);
+        flattened["coordinates"] = coordinates;
+
+        // Generate CSV columns and data
+        const csvColumns = Object.keys(flattened);
+        const csvData = Object.values(flattened).map((value) =>
+          typeof value === "string" && value.includes(",")
+            ? `"${value.replace(/"/g, '""')}"`
+            : value
+        );
+
+        // Append geometry type at the end
+        csvColumns.push("geometry type");
+        csvData.push(`"${geometry.type}"`);
+
+        // Write header only once
+        if (!headerWritten) {
+          csvString += csvColumns.join(",") + "\n";
+          headerWritten = true;
+        }
+
+        // Append the data row
+        csvString += csvData.join(",") + "\n";
+      });
+
+      // Download CSV
+      const filename = `${combinedFeatures[0].properties["Territory"]}_alerts.csv`;
+      const blob = new Blob([csvString], { type: "text/csv" });
+
+      const link = document.createElement("a");
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      document.body.appendChild(link);
+
+      link.click();
+
+      // Clean up and free memory
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+    },
+    downloadAllGeoJSON() {
+      if (
+        !this.geojson ||
+        !this.geojson.mostRecentAlerts ||
+        !this.geojson.otherAlerts
+      ) {
+        console.error("No complete GeoJSON data available to download.");
+        return;
+      }
+
+      // Combine features from mostRecentAlerts and otherAlerts
+      const combinedFeatures = [
+      ...this.geojson.otherAlerts.features,
+      ...this.geojson.mostRecentAlerts.features,
+      ];
+
+      combinedFeatures.forEach(feature => {
+        delete feature.properties['image_url'];
+        delete feature.properties['image_caption'];
+        delete feature.properties['preview_link'];
+      });
+
+      // Create a new FeatureCollection GeoJSON object
+      const combinedGeoJSON = {
+        type: "FeatureCollection",
+        features: combinedFeatures,
+      };
+
+      // Convert to string for download
+      const filename = `${combinedGeoJSON.features[0].properties["Territory"]}_alerts.geojson`;
+      const jsonStr = JSON.stringify(combinedGeoJSON, null, 2);
+      const blob = new Blob([jsonStr], { type: "application/json" });
+
+      // Create a link and trigger download
       const link = document.createElement("a");
       link.href = URL.createObjectURL(blob);
       link.download = filename;

--- a/components/FeaturePopup.vue
+++ b/components/FeaturePopup.vue
@@ -4,6 +4,7 @@
     <AlertsIntroPanel 
       v-if="showIntroPanel"
       :statistics="statistics"
+      :allDataGeojson="allDataGeojson"
     />
     <Feature
       v-if="feature"
@@ -17,7 +18,11 @@
       :audio-extensions="audioExtensions"
       :video-extensions="videoExtensions"
     />
-    <Download v-if="showDownloadButtons" :feature-geojson="featureGeojson" />
+    <Download 
+      v-if="downloadAlert" 
+      :geojson="featureGeojson" 
+      :type-of-data="'alert'" 
+    />
   </div>
 </template>
 
@@ -29,6 +34,7 @@ import AlertsIntroPanel from "@/components/AlertsIntroPanel.vue";
 export default {
   components: { AlertsIntroPanel, Feature, Download },
   props: [
+    "allDataGeojson",
     "embedMedia",
     "previewMapLink",
     "mediaBasePath",
@@ -40,7 +46,7 @@ export default {
     "audioExtensions",
     "videoExtensions",
     "showSidebar",
-    "showDownloadButtons",
+    "downloadAlert",
     "showIntroPanel",
     "statistics"
   ],


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/guardianconnector-views/issues/16 (insofar as it ticks the last item off the list!)

This PR uses the `Download` component that was added previously to allow the user to download all of the data as CSV or GeoJSON in the `AlertsIntroPanel` view. 

`Download` now has separate `downloadAlertCSV` / `downloadAlertGeoJSON` and `downloadAllCSV` / `downloadAllGeoJSON` functions, and a `typeOfData` prop passed by an upstream component determines which one is run. (In order to parse the data differently depending on which kind of dataset is passed to it, a singular alert or the entire alert dataset.)