### PR TITLE
Handle geographic centroid calculation for MultiPolygon geometries

### DIFF
--- a/api/dataProcessing/helpers.ts
+++ b/api/dataProcessing/helpers.ts
@@ -42,3 +42,34 @@ export const hasValidCoordinates = (obj: Record<string, any>): boolean => {
     return false;
   });
 };
+
+export const calculateCentroid = (coords: string): string => {
+  let totalLat = 0;
+  let totalLng = 0;
+  let numCoords = 0;
+
+  const allCoords: any = JSON.parse(coords);
+
+  const processCoord = (coord: number[]) => {
+    totalLng += coord[0];
+    totalLat += coord[1];
+    numCoords++;
+  };
+
+  // Check if it's a MultiPolygon (array of array of array)
+  if (Array.isArray(allCoords[0]) && Array.isArray(allCoords[0][0]) && Array.isArray(allCoords[0][0][0])) {
+    allCoords.forEach((polygon: number[][][]) => {
+      polygon.flat().forEach((coord: number[]) => processCoord(coord));
+    });
+  } else if (Array.isArray(allCoords[0]) && Array.isArray(allCoords[0][0])) { // It's a Polygon (array of array)
+    allCoords.flat().forEach((coord: number[]) => processCoord(coord));
+  } else {
+    console.error('Invalid input format');
+    return '';
+  }
+
+  const avgLng = (totalLng / numCoords).toFixed(6);
+  const avgLat = (totalLat / numCoords).toFixed(6);
+
+  return `${avgLat}, ${avgLng}`;
+}

--- a/api/dataProcessing/transformData.ts
+++ b/api/dataProcessing/transformData.ts
@@ -1,5 +1,5 @@
 import { AlertRecord } from "./types";
-import { capitalizeFirstLetter, getRandomColor } from "./helpers";
+import { capitalizeFirstLetter, getRandomColor, calculateCentroid } from "./helpers";
 
 // Transform survey data keys and values
 const transformSurveyData = (
@@ -193,6 +193,7 @@ const prepareAlertData = (
       typeof item.area_alert_ha === "number"
         ? item.area_alert_ha.toFixed(2)
         : item.area_alert_ha;
+    transformedItem["Geographic centroid"] = calculateCentroid(item.g__coordinates);
     transformedItem["Satellite used for detection"] =
       satelliteLookup[item.sat_detect_prefix] || item.sat_detect_prefix;
 

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -206,7 +206,6 @@ export default {
         });
         this.map.on("click", layerId, (e) => {
           let featureObject = e.features[0].properties;
-          featureObject["Geographic centroid"] = this.calculateCentroid(e.features[0].geometry.coordinates[0]);
 
           const featureGeojson = (({ type, geometry, properties }) => ({ type, geometry, properties }))(e.features[0]);
           const featureId = e.features[0].id;
@@ -304,22 +303,6 @@ export default {
       this.selectedFeatureGeojson = null;
       this.selectedFeatureId = null;
       this.selectedFeatureSource = null;
-    },
-
-    calculateCentroid(coords) {
-        let totalLat = 0;
-        let totalLng = 0;
-        const numCoords = coords.length;
-
-        coords.forEach(coord => {
-            totalLng += coord[0];
-            totalLat += coord[1];
-        });
-
-        const avgLng = (totalLng / numCoords).toFixed(6);
-        const avgLat = (totalLat / numCoords).toFixed(6);
-
-        return `${avgLat}, ${avgLng}`;
     },
 
     prepareMapLegendContent() {


### PR DESCRIPTION
This PR resolves a minor bug where the geographic centroid for MultiPolygon features was shown in the dashboard as "NaN, NaN" because the ` calculateCentroid()` function was only set up to handle single Polygon GeoJSON features. 

Now, the function (which has been moved to take place server-side, and converted to TypeScript) checks if the incoming coordinates are MultiPolygon (3 dimensional array) versus Polygon (array of array) and applies additional flattening for the former.