### PR TITLE
Use alerts metadata table to compile statistics for `AlertsDashboard`

### DIFF
--- a/api/dataProcessing/transformData.ts
+++ b/api/dataProcessing/transformData.ts
@@ -263,8 +263,6 @@ const prepareAlertStatistics = (
     metadata: Metadata[] | null
   ): Record<string, any> => {
 
-  console.log(metadata);
-
   const territory =
     data[0].territory_name.charAt(0).toUpperCase() +
     data[0].territory_name.slice(1);
@@ -287,13 +285,39 @@ const prepareAlertStatistics = (
 
   // Sort dates to find the earliest and latest
   formattedDates.sort((a, b) => a.date.getTime() - b.date.getTime());
-  const latestDate = formattedDates[formattedDates.length - 1].date;
-  latestDate.setDate(28);
-  const latestDateStr = formattedDates[formattedDates.length - 1].dateString;
-  const earliestDate = formattedDates[0].date;
-  earliestDate.setDate(1);
-  const earliestDateStr = formattedDates[0].dateString;
+  
+  let earliestDateStr, latestDateStr;
+  let earliestDate: Date, latestDate: Date;
 
+  if (metadata && metadata.length > 0) {
+    // Find earliest and latest dates from metadata
+    metadata.sort((a, b) => (a.year === b.year ? a.month - b.month : a.year - b.year));
+    const earliestMetadata = metadata[0];
+    const latestMetadata = metadata[metadata.length - 1];
+
+    earliestDate = new Date(earliestMetadata.year, earliestMetadata.month - 1, 1);
+    latestDate = new Date(latestMetadata.year, latestMetadata.month - 1, 28);
+
+    earliestDateStr = `${String(earliestMetadata.month).padStart(2, '0')}-${earliestMetadata.year}`;
+    latestDateStr = `${String(latestMetadata.month).padStart(2, '0')}-${latestMetadata.year}`;
+  } else {
+    // If metadata is null, calculate earliest and latest dates from data
+    const formattedDates = data.map((item) => ({
+      date: new Date(`${item.year_detec}-${item.month_detec.padStart(2, "0")}-15`),
+      dateString: `${item.month_detec.padStart(2, "0")}-${item.year_detec}`,
+    }));
+
+    formattedDates.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    earliestDate = formattedDates[0].date;
+    earliestDate.setDate(1);
+    earliestDateStr = formattedDates[0].dateString;
+
+    latestDate = formattedDates[formattedDates.length - 1].date;
+    latestDate.setDate(28);
+    latestDateStr = formattedDates[formattedDates.length - 1].dateString;
+  }
+  
   // Create an array of all dates
   const allDates = Array.from(
     new Set(formattedDates.map((item) => item.dateString)),

--- a/api/dataProcessing/transformData.ts
+++ b/api/dataProcessing/transformData.ts
@@ -1,4 +1,4 @@
-import { AlertRecord } from "./types";
+import { AlertRecord, Metadata } from "./types";
 import {
   capitalizeFirstLetter,
   getRandomColor,
@@ -258,7 +258,13 @@ const prepareAlertData = (
 };
 
 // Prepare statistics for the alerts view intro panel
-const prepareAlertStatistics = (data: AlertRecord[]): Record<string, any> => {
+const prepareAlertStatistics = (
+    data: AlertRecord[],
+    metadata: Metadata[] | null
+  ): Record<string, any> => {
+
+  console.log(metadata);
+
   const territory =
     data[0].territory_name.charAt(0).toUpperCase() +
     data[0].territory_name.slice(1);

--- a/api/dataProcessing/types.ts
+++ b/api/dataProcessing/types.ts
@@ -11,3 +11,11 @@ export type AlertRecord = {
   area_alert_ha: string;
   _topic: string;
 };
+
+export type Metadata = {
+  type_alert: string;
+  month: string;
+  year: string;
+  total_alerts: string;
+  description_alerts: string;
+};

--- a/api/dataProcessing/types.ts
+++ b/api/dataProcessing/types.ts
@@ -14,8 +14,8 @@ export type AlertRecord = {
 
 export type Metadata = {
   type_alert: string;
-  month: string;
-  year: string;
+  month: number;
+  year: number;
   total_alerts: string;
   description_alerts: string;
 };

--- a/api/database/dbOperations.ts
+++ b/api/database/dbOperations.ts
@@ -56,7 +56,7 @@ const fetchData = async (
   db: any,
   table: string | undefined,
   isSQLite: string | undefined,
-): Promise<{ mainData: any[]; columnsData: any[] | null }> => {
+): Promise<{ mainData: any[]; columnsData: any[] | null; metadata: any[] | null ;}> => {
   console.log("Fetching data from", table, "...");
   // Fetch data
   const mainDataExists = await checkTableExists(db, table, isSQLite);
@@ -78,9 +78,20 @@ const fetchData = async (
     columnsData = await fetchDataFromTable(db, `${table}__columns`, isSQLite);
   }
 
+  // Fetch metadata
+  const metadataTableExists = await checkTableExists(
+    db,
+    `${table}_metadata`,
+    isSQLite,
+  );
+  let metadata = null;
+  if (metadataTableExists) {
+    metadata = await fetchDataFromTable(db, `${table}_metadata`, isSQLite);
+  }
+
   console.log("Successfully fetched data from", table, "!");
 
-  return { mainData, columnsData };
+  return { mainData, columnsData, metadata };
 };
 
 export default fetchData;

--- a/api/database/dbOperations.ts
+++ b/api/database/dbOperations.ts
@@ -75,7 +75,7 @@ const fetchData = async (
   );
   let columnsData = null;
   if (columnsTableExists) {
-    columnsData = await fetchDataFromTable(db, `${table}__columns`, isSQLite);
+    columnsData = await fetchDataFromTable(db, `${table}___columns`, isSQLite);
   }
 
   // Fetch metadata
@@ -86,7 +86,7 @@ const fetchData = async (
   );
   let metadata = null;
   if (metadataTableExists) {
-    metadata = await fetchDataFromTable(db, `${table}_metadata`, isSQLite);
+    metadata = await fetchDataFromTable(db, `${table}__metadata`, isSQLite);
   }
 
   console.log("Successfully fetched data from", table, "!");

--- a/api/index.ts
+++ b/api/index.ts
@@ -167,7 +167,7 @@ if (!VIEWS_CONFIG) {
         async (_req: express.Request, res: express.Response) => {
           try {
             // Fetch data
-            const { mainData } = await fetchData(db, table, IS_SQLITE);
+            const { mainData, metadata } = await fetchData(db, table, IS_SQLITE);
 
             // Prepare alerts data for the alerts view
             const changeDetectionData = prepareAlertData(
@@ -176,7 +176,7 @@ if (!VIEWS_CONFIG) {
             );
 
             // Prepare statistics data for the alerts view
-            const statistics = prepareAlertStatistics(mainData);
+            const statistics = prepareAlertStatistics(mainData, metadata);
 
             // Convert alert data to GeoJSON format
             const geojsonData = {


### PR DESCRIPTION
## Goal

To use an alerts metadata table, if found, to compile some of the statistics for alerts on the `AlertsDashboard` component. 

This PR supplements the proposed work in https://github.com/ConservationMetrics/frizzle/issues/134 to create an `{table_alias}__metadata` table from a CSV published by a change detection data alerts provider.

## Screenshots

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/a9682254-18d3-473b-98fc-e250282fa792)
_This shows an alert detection range of up to January 2024, but date of most recent alerts published in December 2023. 
In other words, no alerts were generated in January 2024._

## What I changed

* In `fetchData`, fetch and return the `__metadata` table if it exists, much like we do for `__columns` tables generated by frizzle.
* In `prepareAlertStatistics`, if metadata is provided, use the month and year fields to populate the earliest and latest dates.

## What I'm not doing here

Using the alerts metadata to update some of the other statistics fields, such as `alertsTotal`, `recentAlertsDate`, or `recentAlertsNumber`. I've gone back and forth on whether to use the metadata or the actual alerts published as the source of truth for these. I'm opting for the actual alerts published, because there could be an edge case scenario where there is a mismatch between the CSV and the actual alerts published, in which case we'll want the statistics to reflect what's actually shown on the map.