### PR TITLE
`prepareAlertStatistics` provides cumulative data for alerts per month

### DIFF
--- a/api/dataProcessing/types.ts
+++ b/api/dataProcessing/types.ts
@@ -19,3 +19,5 @@ export type Metadata = {
   total_alerts: string;
   description_alerts: string;
 };
+
+export type AlertsPerMonth = Record<string, number>;


### PR DESCRIPTION
## Goal

Taking up a good suggestion by @mmckown in Suriname, this PR adapts the `prepareAlertStatistics` API function to provide cumulative data for the alerts dashboard.

## Screenshots

Before:
![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/94a07ee7-ad12-4edc-b46c-e38248da3896)

After:
![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/5549e265-c82c-4c4d-9211-260d0f7b592d)

## What I changed

* I created a helper function `updateCumulativeData` that cumulatively sums either alerts or hectares for each month, and use that function to populate `alertsPerMonth` and `hectaresPerMonth`.
* Some unrelated linting changes made their way in, reminding me that I need to apply auto-linting on commits for this repo.
* Moved a TypeScript type used in the function to `types.ts` to be consistent.