### PR TITLE
Don't apply mouse event listeners to alert layers that add a stroke for a polygon

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -312,8 +312,8 @@ export default {
       // Add event listeners for layers that start with 'recent-alerts' and 'alerts'
       this.map.getStyle().layers.forEach((layer) => {
         if (
-          layer.id.startsWith("recent-alerts") ||
-          layer.id.startsWith("alerts")
+          layer.id.startsWith("recent-alerts") && !layer.id.includes("stroke") ||
+          layer.id.startsWith("alerts") && !layer.id.includes("stroke")
         ) {
           this.map.on("mouseenter", layer.id, () => {
             this.map.getCanvas().style.cursor = "pointer";


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/guardianconnector-views/issues/41. This PR implements a quick fix to exclude adding event listeners to the alert layers that add a stroke to a polygon, thereby causing the buggy behavior described in #41.