### PR TITLE
Add alerts to map legend, and improve graphic for geometry type

### DIFF
--- a/api/dataProcessing/transformData.ts
+++ b/api/dataProcessing/transformData.ts
@@ -150,7 +150,7 @@ const prepareAlertData = (
   embedMedia: boolean,
 ): {
   mostRecentAlerts: Array<Record<string, any>>;
-  otherAlerts: Array<Record<string, any>>;
+  previousAlerts: Array<Record<string, any>>;
 } => {
   const transformChangeDetectionItem = (
     item: Record<string, any>,
@@ -230,7 +230,7 @@ const prepareAlertData = (
   });
 
   const mostRecentAlerts: Array<Record<string, any>> = [];
-  const otherAlerts: Array<Record<string, any>> = [];
+  const previousAlerts: Array<Record<string, any>> = [];
 
   // Second pass to segregate the data
   data.forEach((item) => {
@@ -250,11 +250,11 @@ const prepareAlertData = (
     if (monthYearStr === latestMonthStr) {
       mostRecentAlerts.push(transformedItem);
     } else {
-      otherAlerts.push(transformedItem);
+      previousAlerts.push(transformedItem);
     }
   });
 
-  return { mostRecentAlerts, otherAlerts };
+  return { mostRecentAlerts, previousAlerts };
 };
 
 // Prepare statistics for the alerts view intro panel

--- a/api/index.ts
+++ b/api/index.ts
@@ -183,7 +183,7 @@ if (!VIEWS_CONFIG) {
               mostRecentAlerts: transformToGeojson(
                 changeDetectionData.mostRecentAlerts,
               ),
-              otherAlerts: transformToGeojson(changeDetectionData.otherAlerts),
+              previousAlerts: transformToGeojson(changeDetectionData.previousAlerts),
             };
 
             const response = {

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -155,7 +155,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#EC00FF",
+              "#FF0000",
             ],
             "fill-opacity": 0.5,
           },
@@ -171,7 +171,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#EC00FF",
+              "#FF0000",
             ],
             "line-width": 2,
           },
@@ -205,7 +205,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#EC00FF",
+              "#FF0000",
             ],
             "line-width": [
               "case",
@@ -245,7 +245,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#FF0000",
+              "#FD8D3C",
             ],
             "fill-opacity": 0.5,
           },
@@ -261,7 +261,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#FF0000",
+              "#FD8D3C",
             ],
             "line-width": 2,
           },
@@ -296,7 +296,7 @@ export default {
               "case",
               ["boolean", ["feature-state", "selected"], false],
               "#FFFF00",
-              "#FF0000",
+              "#FD8D3C",
             ],
             "line-width": [
               "case",
@@ -369,9 +369,9 @@ export default {
             left: 0;
             width: 100%;
             height: 100%;
-            border: 5px solid #EC00FF;
+            border: 5px solid #FF0000;
             border-radius: inherit;
-            box-shadow: 0 0 0 2px #EC00FF;
+            box-shadow: 0 0 0 2px #FF0000;
             animation: pulse 2s infinite;
           }
         `;

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -117,9 +117,9 @@ export default {
           ...this.data.mostRecentAlerts,
           features: filterFeatures(this.data.mostRecentAlerts.features),
         },
-        otherAlerts: {
-          ...this.data.otherAlerts,
-          features: filterFeatures(this.data.otherAlerts.features),
+        previousAlerts: {
+          ...this.data.previousAlerts,
+          features: filterFeatures(this.data.previousAlerts.features),
         },
       };
     },
@@ -135,7 +135,7 @@ export default {
         )
       ) {
         // Add the most recent alerts source to the map as Polygons
-        this.map.addSource("recent-alerts-polygon", {
+        this.map.addSource("most-recent-alerts-polygon", {
           type: "geojson",
           data: {
             ...geoJsonSource.mostRecentAlerts,
@@ -147,9 +147,9 @@ export default {
 
         // Add a layer for most recent alerts Polygons
         this.map.addLayer({
-          id: "recent-alerts-polygon",
+          id: "most-recent-alerts-polygon",
           type: "fill",
-          source: "recent-alerts-polygon",
+          source: "most-recent-alerts-polygon",
           paint: {
             "fill-color": [
               "case",
@@ -163,9 +163,9 @@ export default {
 
         // Add a stroke for most recent alerts Polygons
         this.map.addLayer({
-          id: "recent-alerts-stroke-polygon",
+          id: "most-recent-alerts-stroke-polygon",
           type: "line",
-          source: "recent-alerts-polygon",
+          source: "most-recent-alerts-polygon",
           paint: {
             "line-color": [
               "case",
@@ -185,7 +185,7 @@ export default {
         )
       ) {
         // Add the most recent alerts source to the map as LineStrings
-        this.map.addSource("recent-alerts-linestring", {
+        this.map.addSource("most-recent-alerts-linestring", {
           type: "geojson",
           data: {
             ...geoJsonSource.mostRecentAlerts,
@@ -197,9 +197,9 @@ export default {
 
         // Add a layer for most recent alerts LineStrings
         this.map.addLayer({
-          id: "recent-alerts-linestring",
+          id: "most-recent-alerts-linestring",
           type: "line",
-          source: "recent-alerts-linestring",
+          source: "most-recent-alerts-linestring",
           paint: {
             "line-color": [
               "case",
@@ -218,28 +218,28 @@ export default {
         });
       }
 
-      // Check if the data contains Polygon features for other alerts
+      // Check if the data contains Polygon features for previous alerts
       if (
-        geoJsonSource.otherAlerts.features.some(
+        geoJsonSource.previousAlerts.features.some(
           (feature) => feature.geometry.type === "Polygon",
         )
       ) {
-        // Add the other alerts source to the map as Polygons
-        this.map.addSource("alerts-polygon", {
+        // Add the previous alerts source to the map as Polygons
+        this.map.addSource("previous-alerts-polygon", {
           type: "geojson",
           data: {
-            ...geoJsonSource.otherAlerts,
-            features: geoJsonSource.otherAlerts.features.filter(
+            ...geoJsonSource.previousAlerts,
+            features: geoJsonSource.previousAlerts.features.filter(
               (feature) => feature.geometry.type === "Polygon",
             ),
           },
         });
 
-        // Add a layer for other alerts Polygons
+        // Add a layer for previous alerts Polygons
         this.map.addLayer({
-          id: "alerts-polygon",
+          id: "previous-alerts-polygon",
           type: "fill",
-          source: "alerts-polygon",
+          source: "previous-alerts-polygon",
           paint: {
             "fill-color": [
               "case",
@@ -251,11 +251,11 @@ export default {
           },
         });
 
-        // Add a stroke for other alerts Polygons
+        // Add a stroke for previous alerts Polygons
         this.map.addLayer({
-          id: "alerts-stroke-polygon",
+          id: "previous-alerts-stroke-polygon",
           type: "line",
-          source: "alerts-polygon",
+          source: "previous-alerts-polygon",
           paint: {
             "line-color": [
               "case",
@@ -268,28 +268,28 @@ export default {
         });
       }
 
-      // Check if the data contains LineString features for other alerts
+      // Check if the data contains LineString features for previous alerts
       if (
-        geoJsonSource.otherAlerts.features.some(
+        geoJsonSource.previousAlerts.features.some(
           (feature) => feature.geometry.type === "LineString",
         )
       ) {
-        // Add the other alerts source to the map as LineStrings
-        this.map.addSource("alerts-linestring", {
+        // Add the previous alerts source to the map as LineStrings
+        this.map.addSource("previous-alerts-linestring", {
           type: "geojson",
           data: {
-            ...geoJsonSource.otherAlerts,
-            features: geoJsonSource.otherAlerts.features.filter(
+            ...geoJsonSource.previousAlerts,
+            features: geoJsonSource.previousAlerts.features.filter(
               (feature) => feature.geometry.type === "LineString",
             ),
           },
         });
 
-        // Add a layer for other alerts linestrings
+        // Add a layer for previous alerts linestrings
         this.map.addLayer({
-          id: "alerts-linestring",
+          id: "previous-alerts-linestring",
           type: "line",
-          source: "alerts-linestring",
+          source: "previous-alerts-linestring",
           filter: ["==", "$type", "LineString"],
           paint: {
             "line-color": [
@@ -309,11 +309,11 @@ export default {
         });
       }
 
-      // Add event listeners for layers that start with 'recent-alerts' and 'alerts'
+      // Add event listeners for layers that start with 'most-recent-alerts' and 'alerts'
       this.map.getStyle().layers.forEach((layer) => {
         if (
-          layer.id.startsWith("recent-alerts") && !layer.id.includes("stroke") ||
-          layer.id.startsWith("alerts") && !layer.id.includes("stroke")
+          layer.id.startsWith("most-recent-alerts") && !layer.id.includes("stroke") ||
+          layer.id.startsWith("previous-alerts") && !layer.id.includes("stroke")
         ) {
           this.map.on("mouseenter", layer.id, () => {
             this.map.getCanvas().style.cursor = "pointer";
@@ -327,14 +327,14 @@ export default {
         }
       });
 
-      // Check mostRecentAlerts and otherAlerts for LineString features
+      // Check mostRecentAlerts and previousAlerts for LineString features
       // If found, set hasLineStrings state to true to activate methods
       // relevant to lineStrings
       this.hasLineStrings =
         geoJsonSource.mostRecentAlerts.features.some(
           (feature) => feature.geometry.type === "LineString",
         ) ||
-        geoJsonSource.otherAlerts.features.some(
+        geoJsonSource.previousAlerts.features.some(
           (feature) => feature.geometry.type === "LineString",
         );
     },
@@ -380,10 +380,10 @@ export default {
       styleSheet.innerText = styles;
       document.head.appendChild(styleSheet);
 
-      // Check for sources that start with 'recent-alerts'
+      // Check for sources that start with 'most-recent-alerts'
       const sources = this.map.getStyle().sources;
       const recentAlertsSources = Object.keys(sources).filter((source) =>
-        source.startsWith("recent-alerts"),
+        source.startsWith("most-recent-alerts"),
       );
 
       recentAlertsSources.forEach((sourceId) => {
@@ -473,7 +473,7 @@ export default {
       ];
 
       const features = this.map.queryRenderedFeatures(bbox, {
-        layers: ['recent-alerts-linestring', 'alerts-linestring']
+        layers: ['most-recent-alerts-linestring', 'previous-alerts-linestring']
       });
 
       if (features.length > 0) {
@@ -491,7 +491,7 @@ export default {
       ];
 
       const features = this.map.queryRenderedFeatures(bbox, {
-        layers: ["recent-alerts-linestring", "alerts-linestring"],
+        layers: ["most-recent-alerts-linestring", "previous-alerts-linestring"],
       });
 
       if (features.length) {
@@ -519,7 +519,7 @@ export default {
       this.$nextTick(() => {
         this.map.getStyle().layers.forEach((layer) => {
           if (
-            layer.id.startsWith("recent-alerts") ||
+            layer.id.startsWith("most-recent-alerts") ||
             layer.id.startsWith("alerts")
           ) {
             this.map.setFilter(layer.id, [
@@ -530,10 +530,10 @@ export default {
           }
         });
 
-        // If 'recent-alerts' layers are empty, remove the pulsing circles. If not, add them.
+        // If 'most-recent-alerts' layers are empty, remove the pulsing circles. If not, add them.
         const recentAlertsLayers = this.map
           .getStyle()
-          .layers.filter((layer) => layer.id.startsWith("recent-alerts"));
+          .layers.filter((layer) => layer.id.startsWith("most-recent-alerts"));
         let recentAlertsFeatures = [];
         recentAlertsLayers.forEach((layer) => {
           recentAlertsFeatures.push(
@@ -567,7 +567,7 @@ export default {
     isOnlyLineStringData() {
       const allFeatures = [
         ...this.data.mostRecentAlerts.features,
-        ...this.data.otherAlerts.features,
+        ...this.data.previousAlerts.features,
       ];
       return allFeatures.every(
         (feature) => feature.geometry.type === "LineString",
@@ -575,13 +575,18 @@ export default {
     },
 
     prepareMapLegendContent() {
-      if (!this.mapLegendLayerIds) {
-        return;
-      }
       this.map.once("idle", () => {
+        // Add most-recent-alerts & previous-alerts layers to mapLegendContent
+        let mapLegendLayerIds = this.mapLegendLayerIds;
+        if (this.hasLineStrings) {
+          mapLegendLayerIds = "most-recent-alerts-linestring,previous-alerts-linestring," + mapLegendLayerIds;
+        } else {
+          mapLegendLayerIds = "most-recent-alerts-polygon,previous-alerts-polygon," + mapLegendLayerIds;
+        }
+
         this.mapLegendContent = prepareMapLegendLayers(
           this.map,
-          this.mapLegendLayerIds,
+          mapLegendLayerIds,
         );
       });
     },
@@ -613,10 +618,10 @@ export default {
       this.imageCaption = null;
       this.selectedDateRange = null;
 
-      // Reset the filters for layers that start with 'recent-alerts' and 'alerts'
+      // Reset the filters for layers that start with 'most-recent-alerts' and 'alerts'
       this.map.getStyle().layers.forEach((layer) => {
         if (
-          layer.id.startsWith("recent-alerts") ||
+          layer.id.startsWith("most-recent-alerts") ||
           layer.id.startsWith("alerts")
         ) {
           this.map.setFilter(layer.id, null);

--- a/components/AlertsIntroPanel.vue
+++ b/components/AlertsIntroPanel.vue
@@ -14,7 +14,7 @@
         </h2>
         <p class="text-l mb-2">
           Most recent alerts shown on map in
-          <span style="color: #ec00ff"><strong>purple</strong></span
+          <span style="color: #FF0000"><strong>red</strong></span
           >.
         </p>
         <div class="mb-2">

--- a/components/MapLegend.vue
+++ b/components/MapLegend.vue
@@ -45,6 +45,8 @@ export default {
 }
 
 .fill-box {
+  border-radius: 30% 70% 70% 30% / 30% 30% 70% 70% !important;
+  transform: rotate(60deg);
 }
 
 .line-box {
@@ -55,7 +57,11 @@ export default {
 }
 
 .circle-box {
-  border-radius: 50%;
+  border-radius: 50%;  
+  width: 10px;
+  height: 10px;
+  margin: 5px;
+  margin-right: 15px;
 }
 
 .legend-item {

--- a/src/mapFunctions.ts
+++ b/src/mapFunctions.ts
@@ -48,9 +48,12 @@ export function prepareMapLegendLayers(
         return;
       }
 
-      const formattedId = layerId
+      let formattedId = layerId
         .replace(/-/g, " ")
         .replace(/^\w/, (m) => m.toUpperCase());
+
+      // if formattedId ends with polygon or linestring, remove it
+      formattedId = formattedId.replace(/ polygon| linestring$/i, "");
 
       return {
         id: formattedId,


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/guardianconnector-views/issues/43.

## Goal

To add alerts from the Alerts Dashboard component to the Map Legend, and to improve the legend graphic for polygons and point geometries.

## Screenshots

Linestring alerts - before & after
![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/2ea791e2-945d-4369-ad0c-5bb09cfabffb) ![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/8ba43c1e-5f2f-403a-8ff1-692d0d16e920)

Polygon alerts - before & after
![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/eb6a8fd7-7735-44fe-afd4-5a770874224d) ![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/461526f1-650f-445f-9f93-391d452a87ca)

## What I changed

* Renamed `otherAlerts` to `previousAlerts` in a bunch of places for purposes of clear and consistent naming. Also renamed `recentAlerts` to `mostRecentAlerts`.
* On the `AlertsDashboard` component, add the alerts map legend layer IDs to be included in the string of layer IDs to be processed by `prepareMapLegendLayers`.
* Modify the CSS props for the polygon and circle geometries to better resemble how they might look on the map.