### PR TITLE
Patch: Fix alerts date slider, and download buttons for all data

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -595,7 +595,7 @@ export default {
         this.map.getStyle().layers.forEach((layer) => {
           if (
             layer.id.startsWith("most-recent-alerts") ||
-            layer.id.startsWith("alerts")
+            layer.id.startsWith("previous-alerts")
           ) {
             this.map.setFilter(layer.id, [
               "all",

--- a/components/Download.vue
+++ b/components/Download.vue
@@ -128,15 +128,15 @@ export default {
       if (
         !this.geojson ||
         (this.geojson.mostRecentAlerts.features.length <= 0 &&
-          this.geojson.otherAlerts.features.length <= 0)
+          this.geojson.previousAlerts.features.length <= 0)
       ) {
         console.warn("No complete GeoJSON data available to download as CSV.");
         return;
       }
 
-      // Combine features from mostRecentAlerts and otherAlerts
+      // Combine features from mostRecentAlerts and previousAlerts
       const combinedFeatures = [
-        ...this.geojson.otherAlerts.features,
+        ...this.geojson.previousAlerts.features,
         ...this.geojson.mostRecentAlerts.features,
       ];
 
@@ -181,6 +181,7 @@ export default {
       });
 
       // Download CSV
+      const filename = `${combinedFeatures[0].properties["Territory"]}_alerts.csv`;
       const blob = new Blob([csvString], { type: "text/csv" });
 
       const link = document.createElement("a");
@@ -198,15 +199,15 @@ export default {
       if (
         !this.geojson ||
         (this.geojson.mostRecentAlerts.features.length <= 0 &&
-          this.geojson.otherAlerts.features.length <= 0)
+          this.geojson.previousAlerts.features.length <= 0)
       ) {
         console.warn("No complete GeoJSON data available to download.");
         return;
       }
 
-      // Combine features from mostRecentAlerts and otherAlerts
+      // Combine features from mostRecentAlerts and previousAlerts
       const combinedFeatures = [
-        ...this.geojson.otherAlerts.features,
+        ...this.geojson.previousAlerts.features,
         ...this.geojson.mostRecentAlerts.features,
       ];
 


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/guardianconnector-views/issues/49.

## What I changed

* Fixed some var names that were not yet updated for the refactor work in https://github.com/ConservationMetrics/guardianconnector-views/pull/45.