### PR TITLE
Separate media paths for alerts & mapeo data on `AlertsDashboard`

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -34,6 +34,7 @@ interface ViewConfig {
   MAPEO_CATEGORY_IDS: string;
   MAP_LEGEND_LAYER_IDS: string;
   MEDIA_BASE_PATH: string;
+  MEDIA_BASE_PATH_ALERTS: string;
   LOGO_URL: string;
   PLANET_API_KEY: string;
   UNWANTED_COLUMNS?: string;

--- a/api/index.ts
+++ b/api/index.ts
@@ -244,6 +244,7 @@ if (!VIEWS_CONFIG) {
               mapboxZoom: VIEWS[table].MAPBOX_ZOOM,
               mapeoData: mapeoData,
               mediaBasePath: VIEWS[table].MEDIA_BASE_PATH,
+              mediaBasePathAlerts: VIEWS[table].MEDIA_BASE_PATH_ALERTS,
               planetApiKey: VIEWS[table].PLANET_API_KEY,
               statistics: statistics,
               table: table,

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -22,6 +22,7 @@
       :is-alert="isAlert"
       :logo-url="logoUrl"
       :media-base-path="mediaBasePath"
+      :media-base-path-alerts="mediaBasePathAlerts"
       :show-intro-panel="showIntroPanel"
       :show-sidebar="showSidebar"
       :show-slider="showSlider"
@@ -79,6 +80,7 @@ export default {
     "mapboxZoom",
     "mapeoData",
     "mediaBasePath",
+    "mediaBasePathAlerts",
     "planetApiKey",
     "statistics",
   ],
@@ -842,7 +844,11 @@ export default {
       this.imageUrl = [];
       featureObject.t0_url && this.imageUrl.push(featureObject.t0_url);
       featureObject.t1_url && this.imageUrl.push(featureObject.t1_url);
-      featureObject["Photos"] && this.imageUrl.push(featureObject["Photos"]);
+      if (featureObject["Photos"]) {
+        const photos = featureObject["Photos"].split(',');
+        photos.forEach(photo => this.imageUrl.push(photo.trim()));
+      }
+
       delete featureObject["t0_url"], delete featureObject["t1_url"];
       delete featureObject["filter-color"];
 

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -22,7 +22,7 @@
         :filePath="filePath"
         :image-extensions="imageExtensions"
         :key="filePath"
-        :mediaBasePath="mediaBasePath"
+        :mediaBasePath="setMediaBasePath()"
         :video-extensions="videoExtensions"
       />
     </div>
@@ -81,9 +81,18 @@ export default {
     "imageExtensions",
     "isAlert",
     "mediaBasePath",
+    "mediaBasePathAlerts",
     "videoExtensions",
   ],
-  methods: {},
+  methods: {
+    setMediaBasePath() {
+      if (this.isAlert) {
+        return this.mediaBasePathAlerts;
+      } else {
+        return this.mediaBasePath;
+      }
+    }
+  },
 };
 </script>
 

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -22,6 +22,7 @@
       :image-extensions="imageExtensions"
       :is-alert="isAlert"
       :media-base-path="mediaBasePath"
+      :media-base-path-alerts="mediaBasePathAlerts"
       :video-extensions="videoExtensions"
     />
     <Download
@@ -54,6 +55,7 @@ export default {
     "isAlert",
     "logoUrl",
     "mediaBasePath",
+    "mediaBasePathAlerts",
     "showIntroPanel",
     "showSidebar",
     "showSlider",

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,6 +40,8 @@ If your alerts data comes with map resources to visualize, then you can set this
 
 Enables embedding of media filenames from the database in the Gallery or Map views. Set to `YES` and specify the base path for media files in `MEDIA_BASE_PATH`. If neither are set, the gallery view will be disabled for this table.
 
+For alerts, you need to provide a separate base path for alerts. Append your `MEDIA_BASE_PATH` variable with `_ALERTS`. If you are also using Mapeo data, then provide a separate `MEDIA_BASE_PATH` value.
+
 #### `FRONT_END_FILTERING` (optional)
 
 Activates a dropdown filter for data in views. Set to `YES` and define the field for filtering in `FRONT_END_FILTER_FIELD`.

--- a/pages/alerts/_tablename.vue
+++ b/pages/alerts/_tablename.vue
@@ -19,6 +19,7 @@
       :mapbox3d="mapbox3d"
       :mapeo-data="mapeoData"
       :media-base-path="mediaBasePath"
+      :media-base-path-alerts="mediaBasePathAlerts"
       :planet-api-key="planetApiKey"
       :statistics="statistics"
     />
@@ -75,6 +76,7 @@ export default {
         mapboxZoom: response.mapboxZoom,
         mapeoData: response.mapeoData,
         mediaBasePath: response.mediaBasePath,
+        mediaBasePathAlerts: response.mediaBasePathAlerts,
         planetApiKey: response.planetApiKey,
         statistics: response.statistics,
       };


### PR DESCRIPTION
## Goal

Closes #56.

## What I changed

We are now providing a separate media path where alerts are found, as distinct from Mapeo data. 

Also, I implemented a fix for providing filepaths for Mapeo observations that have multiple attachments.