### PR TITLE
persist locale

### DIFF
--- a/components/shared/LanguagePicker.vue
+++ b/components/shared/LanguagePicker.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import type { SupportedLocale } from "@/types/types";
 
 const { locale, locales, setLocale } = useI18n();
 
@@ -15,8 +16,17 @@ const currentLocaleName = computed(() => {
 
 const dropdownOpen = ref(false);
 
+// Load locale from session storage on mount
+onMounted(() => {
+  const savedLocale = sessionStorage.getItem("locale");
+  if (savedLocale && locales.value.some((lang) => lang.code === savedLocale)) {
+    setLocale(savedLocale as SupportedLocale);
+  }
+});
+
 const changeLocale = (locale: { code: string }): void => {
-  setLocale(locale.code as "en" | "es" | "pt" | "nl");
+  setLocale(locale.code as SupportedLocale);
+  sessionStorage.setItem("locale", locale.code);
   dropdownOpen.value = false;
 };
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -115,12 +115,15 @@ const shouldShowConfigLink = computed(() => {
 // Handle unauthorized access toast
 onMounted(async () => {
   if (route.query.reason === "unauthorized") {
-    showErrorToast(
-      t("accessDenied"),
-      t("accessDeniedMessage"),
-      8000,
-      "top-center",
-    );
+    // Small delay to ensure locale is loaded from session storage
+    setTimeout(() => {
+      showErrorToast(
+        t("accessDenied"),
+        t("accessDeniedMessage"),
+        8000,
+        "top-center",
+      );
+    }, 200);
     router.replace({ path: route.path, query: {} });
   }
 });

--- a/types/types.ts
+++ b/types/types.ts
@@ -147,6 +147,8 @@ export const Role = {
 
 export type Role = (typeof Role)[keyof typeof Role];
 
+export type SupportedLocale = "en" | "es" | "pt" | "nl";
+
 export interface User {
   auth0: string;
   roles?: Array<{ id: string; name: string; description: string }>;


### PR DESCRIPTION
## Goal
Improve language persistence across page refreshes to prevent jarring user experience when language resets. Closes #186 
## Screenshots 
<img width="1470" height="956" alt="Screenshot 2025-09-18 at 11 30 34" src="https://github.com/user-attachments/assets/c23c8e68-584b-42ee-a973-a9b6db603741" />

https://github.com/user-attachments/assets/de564a34-83ff-45ec-b8ca-d06bc8c2044c


## What I changed

### Language Persistence
- **Enhanced `LanguagePicker.vue`** with session storage persistence:
  - Added `onMounted()` hook to restore saved locale from session storage
  - Modified `changeLocale()` to save selected locale to session storage
  - **Added 200ms delay** in unauthorized access toast to ensure locale is fully loaded before displaying translated text


## What I'm not doing here
- Not changing the core authentication/authorization logic
- Not modifying the toast component itself, only the timing