### PR TITLE
Create Database Operations for Annotated Collections

### DIFF
--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -405,10 +405,6 @@ export const updateAnnotatedCollection = async (
       updateFields.push(`description = $${paramCount++}`);
       updateValues.push(updates.description);
     }
-    if (updates.status !== undefined) {
-      updateFields.push(`status = $${paramCount++}`);
-      updateValues.push(updates.status);
-    }
     if (updates.metadata !== undefined) {
       updateFields.push(`metadata = $${paramCount++}`);
       updateValues.push(JSON.stringify(updates.metadata));
@@ -440,6 +436,14 @@ export const updateAnnotatedCollection = async (
         if (incidentUpdates.incident_type !== undefined) {
           incidentUpdateFields.push(`incident_type = $${incidentParamCount++}`);
           incidentUpdateValues.push(incidentUpdates.incident_type);
+        }
+        if (incidentUpdates.status !== undefined) {
+          incidentUpdateFields.push(`status = $${incidentParamCount++}`);
+          incidentUpdateValues.push(incidentUpdates.status);
+        }
+        if (incidentUpdates.is_active !== undefined) {
+          incidentUpdateFields.push(`is_active = $${incidentParamCount++}`);
+          incidentUpdateValues.push(incidentUpdates.is_active);
         }
         if (incidentUpdates.responsible_party !== undefined) {
           incidentUpdateFields.push(
@@ -568,7 +572,6 @@ export const listAnnotatedCollections = async (
   db: DatabaseConnection,
   filters?: {
     collection_type?: string;
-    status?: string;
     created_by?: string;
     limit?: number;
     offset?: number;
@@ -590,12 +593,6 @@ export const listAnnotatedCollections = async (
       conditions.push(`collection_type = $${paramCount++}`);
       queryParams.push(filters.collection_type);
     }
-
-    if (filters.status) {
-      conditions.push(`status = $${paramCount++}`);
-      queryParams.push(filters.status);
-    }
-
     if (filters.created_by) {
       conditions.push(`created_by = $${paramCount++}`);
       queryParams.push(filters.created_by);


### PR DESCRIPTION
## Goal

Closes #199  . This PR is the second PR in the attempt to cherry pick, staggered PR #191 .It adds the database operations for annotated collections. 

## Screenshots
N/A

## What I changed
- Added `createAnnotatedCollection()` - creates collections with type-specific data
- Added `getAnnotatedCollection()` - retrieves collection with entries and incident data
- Added `updateAnnotatedCollection()` - updates collection and incident metadata
- Added `addEntriesToCollection()` - adds source data entries to collections
- Added `deleteAnnotatedCollection()` - removes collections
- Added `listAnnotatedCollections()` - lists collections with filtering and pagination
- Fixed async/await patterns (removed Promise executor anti-patterns)
## What I'm not doing here

