### PR TITLE
Give `main` branch Docker images a unique build tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -156,6 +156,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Generate date for image tag
+        id: imgtag_date
+        run: echo "DATE_FOR_IMGTAG=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -171,6 +174,7 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ github.ref == 'refs/heads/main' && 'communityfirst/guardianconnector-explorer:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && format('communityfirst/guardianconnector-explorer:{0}-{1}', steps.imgtag_date.outputs.DATE_FOR_IMGTAG, github.run_number) || '' }}
             communityfirst/guardianconnector-explorer:ci-test
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker Hub Description


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).


## Goal
Previously Docker images build off `main` branch only got the tag `:latest`. This PR also gives them a unique tag so that deployments can target it without fear of auto-upgrade.

This PR does NOT touch images built from unmerged PRs.  Those still get tagged as `pr-##`


Closes: #112 

## What I changed

As the app itself is "unversioned" (in the sense of no SemVer), the tag reflects the **build** date and Github Actions run number.  Example:

    :20251013-378



## LLM use disclosure
I used Gemini Code Assist to come up with how to do this, since I am not very familiar with Github Actions YML syntax. Then I tested the result (having only omitted the `github.ref == 'refs/heads/main' &&` gate on a feature branch), and confirm that it pushed an appropriately-tagged image to Docker hub.