### PR TITLE
Move Mapeo data to the top of the legend

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -956,6 +956,17 @@ const prepareMapLegendContent = () => {
   map.value.once("idle", () => {
     const legendItems: MapLegendItem[] = [];
 
+    // Add mapeo-data layer first to ensure it's always on top
+    if (props.mapeoData) {
+      legendItems.push({
+        id: "mapeo-data",
+        name: "Mapeo data",
+        type: "circle",
+        color: mapeoDataColor.value || "#000000",
+        visible: true,
+      });
+    }
+
     // Add most recent alerts as a single grouped entry
     if (props.alertsData.mostRecentAlerts.features.length > 0) {
       legendItems.push({
@@ -974,17 +985,6 @@ const prepareMapLegendContent = () => {
         name: "Previous alerts",
         type: "circle",
         color: "#FD8D3C",
-        visible: true,
-      });
-    }
-
-    // Add mapeo-data layer to mapLegendContent
-    if (props.mapeoData) {
-      legendItems.push({
-        id: "mapeo-data",
-        name: "Mapeo data",
-        type: "circle",
-        color: mapeoDataColor.value || "#000000",
         visible: true,
       });
     }


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/225.

## Screenshots

<img width="231" height="238" alt="image" src="https://github.com/user-attachments/assets/5e194349-fe0c-4477-bf15-1b2ffca34ac5" />

## What I changed

Easiest of fixes: moved the codeblock where we add `props.mapeoData` to the legend above that which added alerts.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None