### PR TITLE
fix: clustered circles update with date range change via `AlertsSlider`

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -216,6 +216,8 @@ onMounted(() => {
 
   // @ts-expect-error: Expose map instance for Playwright E2E tests; not a standard property on window
   window._testMap = map.value;
+  // @ts-expect-error: Expose test helper for date range changes; not a standard property on window
+  window._testHandleDateRangeChanged = handleDateRangeChanged;
 
   // Apply 3D terrain whenever the style loads
 


### PR DESCRIPTION
## Goal

Fix clustered circles not updating when the date range changes via the slider.

## Screenshots

<img width="931" height="388" alt="image" src="https://github.com/user-attachments/assets/6d80b6fd-3d12-4207-aa69-bb61826a5e06" />

_only most recent alerts_

## What I changed

- Updated `handleDateRangeChanged` to call `setData()` on all alert sources (points, polygons, linestrings, centroids) with filtered data. Clusters are generated from source data, not layer filters, so the source must be updated.
- Updated `resetToInitialState` to restore original source data when resetting.
- Added test assertion to verify source data updates when date range changes.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Claude Sonnet 4.5 for Playwright