### PR TITLE
Add ability to set COLOR_COLUMN and use on front end + filter

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -29,6 +29,7 @@ import type {
 
 const props = defineProps<{
   allowedFileExtensions: AllowedFileExtensions;
+  colorColumn?: string;
   filterColumn: string;
   mapStatistics: MapStatistics;
   mapLegendLayerIds?: string;
@@ -167,6 +168,15 @@ const addDataToMap = () => {
 
   // Add a layer for Point features if present
   if (hasPointFeatures && !map.value.getLayer("data-layer-point")) {
+    // Use colorColumn if specified, otherwise fall back to filter-color
+    const colorExpression = props.colorColumn
+      ? [
+          "coalesce",
+          ["get", props.colorColumn, ["get", "feature"]],
+          ["get", "filter-color", ["get", "feature"]],
+        ]
+      : ["get", "filter-color", ["get", "feature"]];
+
     map.value.addLayer({
       id: "data-layer-point",
       type: "circle",
@@ -174,7 +184,7 @@ const addDataToMap = () => {
       filter: ["==", "$type", "Point"],
       paint: {
         "circle-radius": 8,
-        "circle-color": ["get", "filter-color", ["get", "feature"]],
+        "circle-color": colorExpression,
         "circle-stroke-width": 3,
         "circle-stroke-color": "#fff",
       },
@@ -183,13 +193,22 @@ const addDataToMap = () => {
 
   // Add a layer for LineString features if present
   if (hasLineStringFeatures && !map.value.getLayer("data-layer-linestring")) {
+    // Use colorColumn if specified, otherwise fall back to filter-color
+    const colorExpression = props.colorColumn
+      ? [
+          "coalesce",
+          ["get", props.colorColumn, ["get", "feature"]],
+          ["get", "filter-color", ["get", "feature"]],
+        ]
+      : ["get", "filter-color", ["get", "feature"]];
+
     map.value.addLayer({
       id: "data-layer-linestring",
       type: "line",
       source: "data-source",
       filter: ["==", "$type", "LineString"],
       paint: {
-        "line-color": ["get", "filter-color", ["get", "feature"]],
+        "line-color": colorExpression,
         "line-width": 2,
       },
     });
@@ -197,13 +216,22 @@ const addDataToMap = () => {
 
   // Add a layer for Polygon features if present
   if (hasPolygonFeatures && !map.value.getLayer("data-layer-polygon")) {
+    // Use colorColumn if specified, otherwise fall back to filter-color
+    const colorExpression = props.colorColumn
+      ? [
+          "coalesce",
+          ["get", props.colorColumn, ["get", "feature"]],
+          ["get", "filter-color", ["get", "feature"]],
+        ]
+      : ["get", "filter-color", ["get", "feature"]];
+
     map.value.addLayer({
       id: "data-layer-polygon",
       type: "fill",
       source: "data-source",
       filter: ["==", "$type", "Polygon"],
       paint: {
-        "fill-color": ["get", "filter-color", ["get", "feature"]],
+        "fill-color": colorExpression,
         "fill-opacity": 0.5,
       },
     });
@@ -375,6 +403,7 @@ onBeforeUnmount(() => {
       v-if="filterColumn"
       :data="mapData"
       :filter-column="filterColumn"
+      :color-column="colorColumn"
       :show-colored-dot="true"
       @filter="filterValues"
     />

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -30,6 +30,7 @@ const mapConfigKeys = computed(() => [
   "MAPBOX_3D_TERRAIN_EXAGGERATION",
   "MAP_LEGEND_LAYER_IDS",
   "PLANET_API_KEY",
+  "COLOR_COLUMN",
 ]);
 const mediaKeys = computed(() => ["MEDIA_BASE_PATH", "MEDIA_BASE_PATH_ALERTS"]);
 const alertKeys = computed(() => ["MAPEO_CATEGORY_IDS", "MAPEO_TABLE"]);

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -441,11 +441,33 @@ const handleDrop = (e: DragEvent, dropIndex: number) => {
           @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
         />
       </template>
+
+      <!-- Color Column -->
+      <template v-else-if="key === 'COLOR_COLUMN'">
+        <label :for="`${tableName}-${key}`">{{ $t(toCamelCase(key)) }}</label>
+        <input
+          :id="`${tableName}-${key}`"
+          class="input-field"
+          type="text"
+          placeholder="color"
+          :value="config[key]"
+          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
+        />
+        <p class="field-description">{{ $t("colorColumnDescription") }}</p>
+      </template>
     </div>
   </div>
 </template>
 
 <style scoped>
+.field-description {
+  font-style: italic;
+  color: #666;
+  font-size: 0.9em;
+  margin-top: 4px;
+  margin-bottom: 10px;
+}
+
 .basemaps-description {
   font-style: italic;
   color: #666;

--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -10,6 +10,7 @@ const { t } = useI18n();
 const props = defineProps<{
   data: Dataset;
   filterColumn: string;
+  colorColumn?: string;
   showColoredDot?: boolean;
 }>();
 
@@ -22,7 +23,10 @@ const selectedFilterValue = ref([]);
 const getUniqueFilterValues = computed(() => {
   const allDataFilterValues = props.data.map((item) => {
     const value = item[props.filterColumn];
-    const color = item["filter-color"] || defaultColoredDotColor;
+    // Use colorColumn if specified, otherwise fall back to filter-color
+    const color = props.colorColumn
+      ? item[props.colorColumn] || item["filter-color"] || defaultColoredDotColor
+      : item["filter-color"] || defaultColoredDotColor;
     return {
       label: value !== null && value !== undefined ? value : t("noColumnEntry"),
       value: value,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -27,6 +27,8 @@
   "changeDetectionAlerts": "Change Detection Alerts",
   "clickOnAlertsForMoreInfo": "Click on alerts for more information",
   "clickOnFeaturesForMoreInfo": "Click on map features for more information",
+  "colorColumn": "Color Column",
+  "colorColumnDescription": "Optional: Specify a column name (e.g., 'color') that contains color values (e.g., hex codes like #FF0000). When set, map features and filter dots will use these colors instead of the randomly generated colors.",
   "confidenceLevel": "Confidence level",
   "confidenceLevelGFWGladAlerts": "Probable loss is defined as a single observation to date flagged as loss. If there are repeat loss observations within 4 observations or 180 days it becomes confirmed loss, otherwise, it reverts back to no loss.",
   "confidenceLevelGFWIntegratedAlerts": "Confidence levels help forest monitors prioritize alerts for follow up since satellite-derived data is subject to errors including false alerts. If two or more alert systems detect a change in the same location, we are more confident (&quot;highest confidence&quot;) that these alerts indicate real disturbance. For individual systems, there is a delay before a first detection can be verified by additional satellite passes and thus reach &quot;high confidence.&quot; The integrated layer displays where multiple systems overlap, in some cases providing increased confidence faster than waiting for individual systems to reach high confidence through additional satellite images, which can take weeks or months. False positives are effectively eliminated in the highest confidence class as it's uncommon for two systems to commit the same error since they use different data streams and algorithms.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -27,6 +27,8 @@
   "changeDetectionAlerts": "Alertas de detección de cambios",
   "clickOnAlertsForMoreInfo": "Haga clic en las alertas para obtener más información",
   "clickOnFeaturesForMoreInfo": "Haga clic en las características del mapa para obtener más información",
+  "colorColumn": "Columna de Color",
+  "colorColumnDescription": "Opcional: Especifique un nombre de columna (por ejemplo, 'color') que contenga valores de color (por ejemplo, códigos hexadecimales como #FF0000). Cuando se establece, las características del mapa y los puntos del filtro utilizarán estos colores en lugar de los colores generados aleatoriamente.",
   "confidenceLevel": "Nivel de confianza",
   "confidenceLevelTerrasImazonGoldMining": "1: Alto nivel de confianza. Tiene todas las características de garimpo de oro. 0: Bajo nivel de confianza. Es posible ver la cobertura de la tierra, pero no es posible estar seguro de que se trata de garimpo de oro.",
   "config": "Configuración",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -27,6 +27,8 @@
   "changeDetectionAlerts": "Veranderingsdetectie waarschuwingen",
   "clickOnAlertsForMoreInfo": "Klik op alerts voor meer informatie",
   "clickOnFeaturesForMoreInfo": "Klik op kaartkenmerken voor meer informatie",
+  "colorColumn": "Kleurkolom",
+  "colorColumnDescription": "Optioneel: Specificeer een kolomnaam (bijv. 'color') die kleurwaarden bevat (bijv. hex-codes zoals #FF0000). Indien ingesteld, zullen kaartkenmerken en filterpunten deze kleuren gebruiken in plaats van willekeurig gegenereerde kleuren.",
   "confidenceLevel": "Betrouwbaarheidsniveau",
   "confidenceLevelTerrasImazonGoldMining": "1: Hoog betrouwbaarheidsniveau. Het heeft alle kenmerken van goudmijnen. 0: Laag betrouwbaarheidsniveau. Het is mogelijk om de verandering in landbedekking te zien, maar het is niet mogelijk om zeker te weten dat het goudmijnen is.",
   "config": "Configuratie",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -27,6 +27,8 @@
   "changeDetectionAlerts": "Alertas de detecção de mudança",
   "clickOnAlertsForMoreInfo": "Clique nos alertas para obter mais informações",
   "clickOnFeaturesForMoreInfo": "Clique nos recursos do mapa para obter mais informações",
+  "colorColumn": "Coluna de Cor",
+  "colorColumnDescription": "Opcional: Especifique um nome de coluna (por exemplo, 'color') que contenha valores de cor (por exemplo, códigos hexadecimais como #FF0000). Quando definido, os recursos do mapa e os pontos do filtro usarão essas cores em vez das cores geradas aleatoriamente.",
   "confidenceLevel": "Nível de confiança",
   "confidenceLevelTerrasImazonGoldMining": "1: Alto nível de confiança. Tem todas as características de garimpo de ouro. 0: Baixo nível de confiança. É possível ver a mudança na cobertura da terra, mas não é possível ter certeza de que se trata de garimpo de ouro.",
   "config": "Configuração",

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -12,6 +12,7 @@ const tableRaw = route.params.tablename;
 const table = Array.isArray(tableRaw) ? tableRaw.join("/") : tableRaw;
 
 const allowedFileExtensions = ref();
+const colorColumn = ref();
 const dataFetched = ref(false);
 const filterColumn = ref();
 const mapLegendLayerIds = ref();
@@ -43,6 +44,7 @@ const { data, error } = await useFetch(`/api/${table}/map`, {
 
 if (data.value && !error.value) {
   allowedFileExtensions.value = data.value.allowedFileExtensions;
+  colorColumn.value = data.value.colorColumn;
   dataFetched.value = true;
   filterColumn.value = data.value.filterColumn;
   mapLegendLayerIds.value = data.value.mapLegendLayerIds;
@@ -90,6 +92,7 @@ useHead({
       <MapView
         v-if="dataFetched"
         :allowed-file-extensions="allowedFileExtensions"
+        :color-column="colorColumn"
         :filter-column="filterColumn"
         :map-legend-layer-ids="mapLegendLayerIds"
         :map-statistics="mapStatistics"

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -66,6 +66,7 @@ export default defineEventHandler(async (event: H3Event) => {
 
     const response = {
       allowedFileExtensions: allowedFileExtensions,
+      colorColumn: viewsConfig[table].COLOR_COLUMN,
       data: processedGeoData,
       filterColumn: viewsConfig[table].FRONT_END_FILTER_COLUMN,
       mapLegendLayerIds: viewsConfig[table].MAP_LEGEND_LAYER_IDS,

--- a/test/components/ConfigMap.test.ts
+++ b/test/components/ConfigMap.test.ts
@@ -626,4 +626,53 @@ describe("ConfigMap component", () => {
     expect(vm.basemaps[1].name).toBe("First");
     expect(vm.basemaps[1].isDefault).toBe(false);
   });
+
+  it("renders COLOR_COLUMN field when included in keys", () => {
+    const propsWithColorColumn = {
+      ...baseProps,
+      keys: [...baseProps.keys, "COLOR_COLUMN"],
+    };
+
+    const wrapper = mount(ConfigMap, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const colorColumnInput = wrapper.find('input[id="test_table-COLOR_COLUMN"]');
+    expect(colorColumnInput.exists()).toBe(true);
+  });
+
+  it("updates COLOR_COLUMN value when input changes", async () => {
+    const propsWithColorColumn = {
+      ...baseProps,
+      keys: [...baseProps.keys, "COLOR_COLUMN"],
+    };
+
+    const wrapper = mount(ConfigMap, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const colorColumnInput = wrapper.find('input[id="test_table-COLOR_COLUMN"]');
+    await colorColumnInput.setValue("color");
+
+    expect(wrapper.emitted("updateConfig")).toBeTruthy();
+    const emitted = wrapper.emitted("updateConfig");
+    expect(emitted?.[0]?.[0]).toEqual({ COLOR_COLUMN: "color" });
+  });
+
+  it("displays placeholder for COLOR_COLUMN field", () => {
+    const propsWithColorColumn = {
+      ...baseProps,
+      keys: [...baseProps.keys, "COLOR_COLUMN"],
+    };
+
+    const wrapper = mount(ConfigMap, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const colorColumnInput = wrapper.find('input[id="test_table-COLOR_COLUMN"]');
+    expect(colorColumnInput.attributes("placeholder")).toBe("color");
+  });
 });

--- a/test/components/DataFilter.test.ts
+++ b/test/components/DataFilter.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref, computed } from "vue";
+import DataFilter from "@/components/shared/DataFilter.vue";
+import type { Dataset } from "@/types/types";
+
+Object.assign(globalThis, {
+  ref,
+  computed,
+});
+
+// Mock vue3-select-component
+vi.mock("vue3-select-component", () => ({
+  default: {
+    name: "VueSelect",
+    template: "<div></div>",
+  },
+}));
+
+// Mock i18n
+const mockT = (key: string) => key;
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: mockT,
+  }),
+}));
+
+const baseProps = {
+  data: [
+    {
+      id: "1",
+      category: "Camp",
+      "filter-color": "#ff0000",
+      color: "#B209B2",
+    },
+    {
+      id: "2",
+      category: "Water Source",
+      "filter-color": "#00ff00",
+      color: "#00A8FF",
+    },
+    {
+      id: "3",
+      category: "Camp",
+      "filter-color": "#ff0000",
+      color: "#B209B2",
+    },
+  ] as Dataset,
+  filterColumn: "category",
+  showColoredDot: true,
+};
+
+const globalConfig = {
+  mocks: {
+    $t: mockT,
+  },
+};
+
+describe("DataFilter component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders filter component", () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="data-filter"]').exists()).toBe(true);
+  });
+
+  it("uses filter-color when colorColumn is not set", () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      getUniqueFilterValues: Array<{ label: string; value: string; color: string }>;
+    };
+
+    const campEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Camp",
+    );
+    expect(campEntry?.color).toBe("#ff0000");
+  });
+
+  it("uses colorColumn when specified", () => {
+    const propsWithColorColumn = {
+      ...baseProps,
+      colorColumn: "color",
+    };
+
+    const wrapper = mount(DataFilter, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      getUniqueFilterValues: Array<{ label: string; value: string; color: string }>;
+    };
+
+    const campEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Camp",
+    );
+    expect(campEntry?.color).toBe("#B209B2");
+
+    const waterSourceEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Water Source",
+    );
+    expect(waterSourceEntry?.color).toBe("#00A8FF");
+  });
+
+  it("falls back to filter-color when colorColumn value is missing", () => {
+    const dataWithMissingColor = [
+      {
+        id: "1",
+        category: "Camp",
+        "filter-color": "#ff0000",
+        // No color field
+      },
+      {
+        id: "2",
+        category: "Water Source",
+        "filter-color": "#00ff00",
+        color: "#00A8FF",
+      },
+    ] as Dataset;
+
+    const propsWithColorColumn = {
+      ...baseProps,
+      data: dataWithMissingColor,
+      colorColumn: "color",
+    };
+
+    const wrapper = mount(DataFilter, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      getUniqueFilterValues: Array<{ label: string; value: string; color: string }>;
+    };
+
+    const campEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Camp",
+    );
+    // Should fall back to filter-color
+    expect(campEntry?.color).toBe("#ff0000");
+
+    const waterSourceEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Water Source",
+    );
+    // Should use color column
+    expect(waterSourceEntry?.color).toBe("#00A8FF");
+  });
+
+  it("uses default color when both colorColumn and filter-color are missing", () => {
+    const dataWithoutColors = [
+      {
+        id: "1",
+        category: "Camp",
+        // No color or filter-color fields
+      },
+    ] as Dataset;
+
+    const propsWithColorColumn = {
+      ...baseProps,
+      data: dataWithoutColors,
+      colorColumn: "color",
+    };
+
+    const wrapper = mount(DataFilter, {
+      props: propsWithColorColumn,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      getUniqueFilterValues: Array<{ label: string; value: string; color: string }>;
+    };
+
+    const campEntry = vm.getUniqueFilterValues.find(
+      (item) => item.value === "Camp",
+    );
+    // Should use default color
+    expect(campEntry?.color).toBe("#808080");
+  });
+
+  it("computes unique filter values correctly", () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      getUniqueFilterValues: Array<{ label: string; value: string; color: string }>;
+    };
+
+    // Should have 2 unique values (Camp and Water Source)
+    expect(vm.getUniqueFilterValues).toHaveLength(2);
+  });
+
+  it("emits filter event when selection changes", async () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      selectedFilterValue: { value: string }[];
+      emitFilterSelection: () => void;
+    };
+
+    vm.selectedFilterValue = [{ value: "Camp" }];
+    vm.emitFilterSelection();
+
+    expect(wrapper.emitted("filter")).toBeTruthy();
+    expect(wrapper.emitted("filter")?.[0]).toEqual([[{ value: "Camp" }]]);
+  });
+
+  it("emits 'null' when no selection is made", async () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      selectedFilterValue: never[];
+      emitFilterSelection: () => void;
+    };
+
+    vm.selectedFilterValue = [];
+    vm.emitFilterSelection();
+
+    expect(wrapper.emitted("filter")).toBeTruthy();
+    expect(wrapper.emitted("filter")?.[0]).toEqual(["null"]);
+  });
+});
+

--- a/types/types.ts
+++ b/types/types.ts
@@ -24,6 +24,7 @@ export type RouteLevelPermission = "anyone" | "guest" | "member" | "admin";
 
 export interface ViewConfig {
   ALERT_RESOURCES?: string;
+  COLOR_COLUMN?: string;
   EMBED_MEDIA?: string;
   FILTER_BY_COLUMN?: string;
   FILTER_OUT_VALUES_FROM_COLUMN?: string;


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/232.

## What I changed and why

* **Config UI**: Added optional `COLOR_COLUMN` text field in `ConfigMap` for specifying a data column containing hex color values 
* **Map Rendering**: Updated `MapView` to use colors from the specified column when available, with automatic fallback to randomly generated `filter-color`
* **Data Filter**: Enhanced `DataFilter` to display colored dots using the same color logic for consistent visual representation

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Tests generated by Claude Sonnet 4.5 