### PR TITLE
Set MEDIA_COLUMN field in config, use on frontend to render media

### DIFF
--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   filterColumn: string;
   galleryData: Dataset;
   mediaBasePath: string;
+  mediaColumn?: string;
 }>();
 const filteredData = ref(props.galleryData);
 
@@ -88,7 +89,7 @@ const featureWithPreparedCoordinates = (feature: DataEntry): DataEntry => {
       :key="index"
       :allowed-file-extensions="allowedFileExtensions"
       :feature="featureWithPreparedCoordinates(feature)"
-      :file-paths="getFilePathsWithExtension(feature, allowedFileExtensions)"
+      :file-paths="getFilePathsWithExtension(feature, allowedFileExtensions, mediaColumn)"
       :media-base-path="mediaBasePath"
       :data-testid="`gallery-item-${index}`"
     />

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -45,6 +45,7 @@ const props = defineProps<{
   mapbox3dTerrainExaggeration: number;
   mapData: Dataset;
   mediaBasePath?: string;
+  mediaColumn?: string;
   planetApiKey?: string;
 }>();
 
@@ -383,7 +384,7 @@ onBeforeUnmount(() => {
       :feature="selectedFeature"
       :feature-geojson="selectedFeatureOriginal"
       :file-paths="
-        getFilePathsWithExtension(selectedFeature, allowedFileExtensions)
+        getFilePathsWithExtension(selectedFeature, allowedFileExtensions, mediaColumn)
       "
       :is-alerts-dashboard="false"
       :map-data="mapData"

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -31,7 +31,7 @@ const mapConfigKeys = computed(() => [
   "MAP_LEGEND_LAYER_IDS",
   "PLANET_API_KEY",
 ]);
-const mediaKeys = computed(() => ["MEDIA_BASE_PATH", "MEDIA_BASE_PATH_ALERTS"]);
+const mediaKeys = computed(() => ["MEDIA_BASE_PATH", "MEDIA_BASE_PATH_ALERTS", "MEDIA_COLUMN"]);
 const alertKeys = computed(() => ["MAPEO_CATEGORY_IDS", "MAPEO_TABLE"]);
 const filterKeys = computed(() => [
   "FILTER_OUT_VALUES_FROM_COLUMN",

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -27,6 +27,7 @@ const providerBasePath = ref<MediaProvider>("filebrowser");
 const shareInputBasePath = ref("");
 const providerAlerts = ref<MediaProvider>("filebrowser");
 const shareInputAlerts = ref("");
+const mediaColumn = ref("");
 const isInitializing = ref(true);
 
 /**
@@ -113,6 +114,12 @@ watch(resolvedAlertsPath, (newValue) => {
   }
 });
 
+watch(mediaColumn, (newValue) => {
+  if (!isInitializing.value) {
+    emit("updateConfig", { MEDIA_COLUMN: newValue });
+  }
+});
+
 // Lifecycle
 onMounted(() => {
   if (props.config.MEDIA_BASE_PATH) {
@@ -147,6 +154,10 @@ onMounted(() => {
       providerAlerts.value = "generic";
       shareInputAlerts.value = existing;
     }
+  }
+
+  if (props.config.MEDIA_COLUMN) {
+    mediaColumn.value = props.config.MEDIA_COLUMN;
   }
 
   nextTick(() => {
@@ -325,6 +336,22 @@ onMounted(() => {
           />
         </div>
       </template>
+    </div>
+
+    <!-- MEDIA_COLUMN -->
+    <div v-if="keys.includes('MEDIA_COLUMN')" class="config-field">
+      <label>{{ $t(toCamelCase("MEDIA_COLUMN")) }}</label>
+      <p class="field-hint" style="margin-top: 0; margin-bottom: 0.75em">
+        {{ $t("mediaColumnDescription") }}
+      </p>
+      <input
+        :id="`${tableName}-media-column`"
+        class="input-field"
+        type="text"
+        :value="mediaColumn"
+        placeholder="photo"
+        @input="mediaColumn = ($event.target as HTMLInputElement).value"
+      />
     </div>
   </div>
 </template>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -97,6 +97,8 @@
   "media": "Media",
   "mediaBasePath": "Base path for media",
   "mediaBasePathAlerts": "Base path for alert images",
+  "mediaColumn": "Column to use for media files",
+  "mediaColumnDescription": "Specify the column name containing media file references (e.g., photo, audio). Only values from this column will be rendered as media files. Leave empty to render media from all columns.",
   "modified": "Modified",
   "monthDetected": "Month detected",
   "mostRecentAlerts": "Most recent alerts",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -94,6 +94,8 @@
   "media": "Medios",
   "mediaBasePath": "Ruta base para medios",
   "mediaBasePathAlerts": "Ruta base para imágenes de alertas",
+  "mediaColumn": "Columna a usar para archivos de medios",
+  "mediaColumnDescription": "Especifique el nombre de la columna que contiene referencias de archivos de medios (por ejemplo, foto, audio). Solo los valores de esta columna se representarán como archivos de medios. Dejar vacío para renderizar medios de todas las columnas.",
   "modified": "Modificado",
   "monthDetected": "Mes detectado",
   "mostRecentAlerts": "Alertas más recientes",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -95,6 +95,8 @@
   "media": "Media",
   "mediaBasePath": "Basis pad voor media",
   "mediaBasePathAlerts": "Basis pad voor alert afbeeldingen",
+  "mediaColumn": "Kolom om te gebruiken voor mediabestanden",
+  "mediaColumnDescription": "Specificeer de kolomnaam die verwijzingen naar mediabestanden bevat (bijv. foto, audio). Alleen waarden uit deze kolom worden weergegeven als mediabestanden. Laat leeg om media uit alle kolommen weer te geven.",
   "modified": "Gewijzigd",
   "monthDetected": "Maand gedetecteerd",
   "mostRecentAlerts": "Meest recente alerts",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -94,6 +94,8 @@
   "media": "Mídia",
   "mediaBasePath": "Caminho base para mídia",
   "mediaBasePathAlerts": "Caminho base para imagens de alertas",
+  "mediaColumn": "Coluna a usar para arquivos de mídia",
+  "mediaColumnDescription": "Especifique o nome da coluna que contém referências de arquivos de mídia (por exemplo, foto, áudio). Apenas valores desta coluna serão renderizados como arquivos de mídia. Deixe vazio para renderizar mídia de todas as colunas.",
   "modified": "Modificado",
   "monthDetected": "Mês detectado",
   "mostRecentAlerts": "Alertas mais recentes",

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -14,6 +14,7 @@ const dataFetched = ref(false);
 const filterColumn = ref();
 const galleryData = ref();
 const mediaBasePath = ref();
+const mediaColumn = ref();
 
 const {
   public: { appApiKey },
@@ -32,6 +33,7 @@ if (data.value && !error.value) {
   filterColumn.value = data.value.filterColumn;
   galleryData.value = data.value.data;
   mediaBasePath.value = data.value.mediaBasePath;
+  mediaColumn.value = data.value.mediaColumn;
 } else {
   console.error("Error fetching data:", error.value);
 }
@@ -64,6 +66,7 @@ useHead({
         :gallery-data="galleryData"
         :filter-column="filterColumn"
         :media-base-path="mediaBasePath"
+        :media-column="mediaColumn"
       />
       <h3
         v-if="!mediaBasePath && dataFetched"

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -29,6 +29,7 @@ const mapbox3d = ref(false);
 const mapbox3dTerrainExaggeration = ref(0);
 const mapData = ref();
 const mediaBasePath = ref();
+const mediaColumn = ref();
 const planetApiKey = ref();
 
 const {
@@ -60,6 +61,7 @@ if (data.value && !error.value) {
   mapbox3dTerrainExaggeration.value = data.value.mapbox3dTerrainExaggeration;
   mapData.value = data.value.data;
   mediaBasePath.value = data.value.mediaBasePath;
+  mediaColumn.value = data.value.mediaColumn;
   planetApiKey.value = data.value.planetApiKey;
 } else {
   console.error("Error fetching data:", error.value);
@@ -106,6 +108,7 @@ useHead({
         :mapbox3d-terrain-exaggeration="mapbox3dTerrainExaggeration"
         :map-data="mapData"
         :media-base-path="mediaBasePath"
+        :media-column="mediaColumn"
         :planet-api-key="planetApiKey"
       />
     </ClientOnly>

--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -47,6 +47,7 @@ export default defineEventHandler(async (event: H3Event) => {
     const dataWithFilesOnly = filterDataByExtension(
       dataFilteredByValues,
       allowedFileExtensions,
+      viewsConfig[table].MEDIA_COLUMN,
     );
     // Transform data that was collected using survey apps (e.g. KoBoToolbox, Mapeo)
     const transformedData = transformSurveyData(dataWithFilesOnly);
@@ -56,6 +57,7 @@ export default defineEventHandler(async (event: H3Event) => {
       data: transformedData,
       filterColumn: viewsConfig[table].FRONT_END_FILTER_COLUMN,
       mediaBasePath: viewsConfig[table].MEDIA_BASE_PATH,
+      mediaColumn: viewsConfig[table].MEDIA_COLUMN,
       table: table,
       routeLevelPermission: viewsConfig[table].ROUTE_LEVEL_PERMISSION,
     };

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -84,6 +84,7 @@ export default defineEventHandler(async (event: H3Event) => {
       mapboxBasemaps: basemaps,
       mapboxZoom: Number(viewsConfig[table].MAPBOX_ZOOM),
       mediaBasePath: viewsConfig[table].MEDIA_BASE_PATH,
+      mediaColumn: viewsConfig[table].MEDIA_COLUMN,
       planetApiKey: viewsConfig[table].PLANET_API_KEY,
       table: table,
       routeLevelPermission: viewsConfig[table].ROUTE_LEVEL_PERMISSION,

--- a/server/dataProcessing/filterData.ts
+++ b/server/dataProcessing/filterData.ts
@@ -140,9 +140,12 @@ export const filterGeoData = (
 export const filterDataByExtension = (
   data: DataEntry[],
   extensions: AllowedFileExtensions,
+  mediaColumn?: string,
 ): DataEntry[] => {
   return data.filter((entry) => {
-    return Object.values(entry).some((value) => {
+    const valuesToCheck = mediaColumn ? [entry[mediaColumn]] : Object.values(entry);
+    
+    return valuesToCheck.some((value) => {
       return (
         typeof value === "string" &&
         (extensions.audio.some((ext) => value.toLowerCase().includes(ext)) ||

--- a/test/dataProcessing/filterData.test.ts
+++ b/test/dataProcessing/filterData.test.ts
@@ -73,4 +73,25 @@ describe("filterDataByExtension", () => {
     // the fixture data has 3 entries, but only 1 has media attachments
     expect(result).toHaveLength(1);
   });
+
+  it("should filter data by specific media column when provided", () => {
+    const testData = [
+      { photo: "image1.jpg", icon: "icon1.png", name: "Feature 1" },
+      { photo: "image2.jpg", icon: "icon2.png", name: "Feature 2" },
+      { photo: "", icon: "icon3.png", name: "Feature 3" },
+    ];
+    const extensions = {
+      image: ["jpg", "jpeg", "png", "webp"],
+      audio: ["mp3", "ogg", "wav"],
+      video: ["mov", "mp4", "avi", "mkv"],
+    };
+
+    // Filter by 'photo' column only
+    const result = filterDataByExtension(testData, extensions, "photo");
+
+    // Should only return entries with valid extensions in the 'photo' column
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Feature 1");
+    expect(result[1].name).toBe("Feature 2");
+  });
 });

--- a/types/types.ts
+++ b/types/types.ts
@@ -47,6 +47,7 @@ export interface ViewConfig {
   MAP_LEGEND_LAYER_IDS?: string;
   MEDIA_BASE_PATH?: string;
   MEDIA_BASE_PATH_ALERTS?: string;
+  MEDIA_COLUMN?: string;
   PLANET_API_KEY?: string;
   UNWANTED_COLUMNS?: string;
   UNWANTED_SUBSTRINGS?: string;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,11 +2,14 @@
 export const getFilePathsWithExtension = (
   feature: { [key: string]: unknown },
   allExtensions: { [category: string]: string[] },
+  mediaColumn?: string,
 ): string[] => {
   if (!feature) return [];
 
   const filePaths: string[] = [];
-  Object.keys(feature).forEach((key) => {
+  const keysToProcess = mediaColumn ? [mediaColumn] : Object.keys(feature);
+
+  keysToProcess.forEach((key) => {
     if (typeof feature[key] !== "string") return;
     if (feature[key].includes("attachment")) return;
 


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/233.

## What I changed and why

Added `MEDIA_COLUMN` to config in order to deterministically allow users to choose which of their columns they actually want to render as image/video/audio.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None