### PR TITLE
Fix node-forge vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4757,8 +4757,8 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.2:
+    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp-build@4.8.4:
@@ -12251,7 +12251,7 @@ snapshots:
       http-shutdown: 1.2.2
       jiti: 2.4.2
       mlly: 1.7.4
-      node-forge: 1.3.1
+      node-forge: 1.3.2
       pathe: 1.1.2
       std-env: 3.9.0
       ufo: 1.6.1
@@ -12641,7 +12641,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.2: {}
 
   node-gyp-build@4.8.4: {}
 


### PR DESCRIPTION
## Goal

Ensure `node-forge` is resolved to the patched version (`1.3.2`) across all environments to clear the GitHub security advisory.

## Screenshots
<img width="1345" height="791" alt="Screenshot 2025-12-02 at 17 54 38" src="https://github.com/user-attachments/assets/17944802-1574-4d9e-b6a6-e0ab6dfe828a" />
<img width="1345" height="791" alt="Screenshot 2025-12-02 at 17 54 29" src="https://github.com/user-attachments/assets/00c4b98d-5145-4c3c-b899-a36e6d088ac4" />
<img width="1345" height="791" alt="Screenshot 2025-12-02 at 17 54 24" src="https://github.com/user-attachments/assets/94e24896-71f4-4083-8cda-a1348a81780a" />

Screenshots just to confirm everything works as expected

## What I changed and why

* Regenerated `pnpm-lock.yaml` to pick up the patched `node-forge@1.3.2`.

Reasoning:
`node-forge` is a transitive dependency via `listhen` (used by `@nuxt/image`, `nitropack`, and the Nuxt CLI). The semver range `^1.3.1` already allows `1.3.2`, so the lockfile correctly resolves it. 

## What I'm not doing here

* Not upgrading any Nuxt packages
* Not making any functional code changes

## LLM use disclosure

None