### PR TITLE
Add new config options to support UI work.

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ViewConfig } from "@/types/types";
 import ConfigPermissions from "./ConfigPermissions.vue";
+import ConfigDatasetInfo from "./ConfigDatasetInfo.vue";
 
 const props = defineProps<{
   tableName: string;
@@ -40,6 +41,11 @@ const filterKeys = computed(() => [
   "UNWANTED_SUBSTRINGS",
 ]);
 const otherKeys = computed(() => ["LOGO_URL"]);
+const datasetInfoKeys = computed(() => [
+  "DATASET_TABLE",
+  "VIEW_HEADER_IMAGE",
+  "VIEW_DESCRIPTION",
+]);
 
 // On mounted, set localConfig to props.config
 const originalConfig = ref<ViewConfig>({});
@@ -171,6 +177,13 @@ const handleSubmit = () => {
           :views="availableViews"
           :config="localConfig"
           :keys="otherKeys"
+          @update-config="handleConfigUpdate"
+        />
+        <ConfigDatasetInfo
+          :table-name="tableName"
+          :views="availableViews"
+          :config="localConfig"
+          :keys="datasetInfoKeys"
           @update-config="handleConfigUpdate"
         />
         <ConfigPermissions

--- a/components/config/ConfigDatasetInfo.vue
+++ b/components/config/ConfigDatasetInfo.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import type { ViewConfig } from "@/types/types";
+
+defineProps<{
+  tableName: string;
+  config: ViewConfig;
+  views: Array<string>;
+  keys: Array<string>;
+}>();
+
+const emit = defineEmits(["updateConfig"]);
+</script>
+
+<template>
+  <div class="config-section">
+    <div class="config-header">
+      <h3>{{ $t("dataset") }} {{ $t("configuration") }}</h3>
+    </div>
+    <div v-for="key in keys" :key="key" class="config-field">
+      <template v-if="key === 'DATASET_TABLE'">
+        <label :for="`${tableName}-${key}`">{{ $t("datasetTable") }}</label>
+        <input
+          :id="`${tableName}-${key}`"
+          class="input-field"
+          :placeholder="$t('datasetTablePlaceholder') || 'e.g., Fake Alerts'"
+          type="text"
+          :value="config[key]"
+          @input="
+            (e) =>
+              emit('updateConfig', {
+                [key]: (e.target as HTMLInputElement).value,
+              })
+          "
+        />
+        <p class="text-gray-500 text-sm mt-1">
+          {{
+            $t("datasetTableDescription") ||
+            "Optional: A nicer display name for this dataset"
+          }}
+        </p>
+      </template>
+      <template v-else-if="key === 'VIEW_HEADER_IMAGE'">
+        <label :for="`${tableName}-${key}`">{{ $t("viewHeaderImage") }}</label>
+        <input
+          :id="`${tableName}-${key}`"
+          class="input-field"
+          placeholder="https://…"
+          type="url"
+          :value="config[key]"
+          @input="
+            (e) =>
+              emit('updateConfig', {
+                [key]: (e.target as HTMLInputElement).value,
+              })
+          "
+        />
+        <p class="text-gray-500 text-sm mt-1">
+          {{
+            $t("viewHeaderImageDescription") ||
+            "Optional: URL for the header background image"
+          }}
+        </p>
+      </template>
+      <template v-else-if="key === 'VIEW_DESCRIPTION'">
+        <label :for="`${tableName}-${key}`">{{ $t("viewDescription") }}</label>
+        <textarea
+          :id="`${tableName}-${key}`"
+          class="input-field"
+          rows="3"
+          :placeholder="
+            $t('viewDescriptionPlaceholder') ||
+            'Enter a description for this dataset...'
+          "
+          :value="config[key]"
+          @input="
+            (e) =>
+              emit('updateConfig', {
+                [key]: (e.target as HTMLInputElement).value,
+              })
+          "
+        />
+        <p class="text-gray-500 text-sm mt-1">
+          {{
+            $t("viewDescriptionDescription") ||
+            "Optional: Description of this dataset"
+          }}
+        </p>
+      </template>
+    </div>
+  </div>
+</template>

--- a/components/index/DatasetCard.vue
+++ b/components/index/DatasetCard.vue
@@ -46,14 +46,14 @@ const getPermissionLevel = () => {
           class="text-lg sm:text-xl font-semibold text-gray-800 break-words max-w-full mb-2"
           style="overflow-wrap: anywhere; word-break: break-word; hyphens: auto"
         >
-          {{ String(tableName) }}
+          {{ config.DATASET_TABLE || String(tableName) }}
         </h2>
-        <!-- Description placeholder - to be populated with actual project descriptions -->
-        <!-- <p class="text-sm sm:text-base text-gray-600 mb-4 line-clamp-2">
-          Description lorem ipsum dolor sit amet, consectetur adipiscing
-          elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-          aliqua.
-        </p> -->
+        <p
+          v-if="config.VIEW_DESCRIPTION"
+          class="text-sm sm:text-base text-gray-600 mb-4 line-clamp-2"
+        >
+          {{ config.VIEW_DESCRIPTION }}
+        </p>
       </div>
     </div>
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -47,6 +47,9 @@
   "dataProvider": "Data provider",
   "dataProviders": "Data provider(s)",
   "dataset": "Dataset",
+  "datasetTable": "Dataset Display Name",
+  "datasetTablePlaceholder": "e.g., Fake Alerts",
+  "datasetTableDescription": "Optional: A nicer display name for this dataset",
   "dateRange": "Date range",
   "default": "Default",
   "downloadCSV": "Download CSV",
@@ -169,6 +172,11 @@
   "visibilityPublic": "Public — no sign-in required",
   "visibilityPublicDescription": "Anyone with the link can view.",
   "visibilityRequired": "Please select a visibility level for this dataset.",
+  "viewDescription": "View Description",
+  "viewDescriptionPlaceholder": "Enter a description for this dataset...",
+  "viewDescriptionDescription": "Optional: Description of this dataset",
+  "viewHeaderImage": "View Header Image",
+  "viewHeaderImageDescription": "Optional: URL for the header background image",
   "yourAccessIsPending": "Your access is pending. Please contact a Guardian Connector administrator for account approval.",
   "yourMapboxStyleDefault": "Mapbox - your style (default)"
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -44,6 +44,9 @@
   "dataProvider": "Proveedor de datos",
   "dataProviders": "Proveedor(es) de datos",
   "dataset": "Conjunto de datos",
+  "datasetTable": "Nombre para mostrar del conjunto de datos",
+  "datasetTablePlaceholder": "ej., Alertas falsas",
+  "datasetTableDescription": "Opcional: Un nombre más agradable para este conjunto de datos",
   "dateRange": "Rango de fechas",
   "default": "Predeterminado",
   "downloadCSV": "Descargar CSV",
@@ -166,6 +169,11 @@
   "visibilityPublic": "Público — no se requiere inicio de sesión",
   "visibilityPublicDescription": "Cualquiera con el enlace puede ver.",
   "visibilityRequired": "Por favor, seleccione un nivel de visibilidad para este conjunto de datos.",
+  "viewDescription": "Descripción de la vista",
+  "viewDescriptionPlaceholder": "Ingrese una descripción para este conjunto de datos...",
+  "viewDescriptionDescription": "Opcional: Descripción de este conjunto de datos",
+  "viewHeaderImage": "Imagen de encabezado de la vista",
+  "viewHeaderImageDescription": "Opcional: URL para la imagen de fondo del encabezado",
   "yourAccessIsPending": "Su acceso está pendiente. Ponte en contacto con un administrador de Guardian Connector para la aprobación de su cuenta.",
   "yourMapboxStyleDefault": "Mapbox - su estilo (predeterminado)"
 }

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -45,6 +45,9 @@
   "dataProvider": "Data provider",
   "dataProviders": "Data provider(s)",
   "dataset": "Dataset",
+  "datasetTable": "Weergavenaam dataset",
+  "datasetTablePlaceholder": "bijv., Nepwaarschuwingen",
+  "datasetTableDescription": "Optioneel: Een mooiere weergavenaam voor deze dataset",
   "dateRange": "Datumbereik",
   "default": "Standaard",
   "downloadCSV": "Download CSV",
@@ -167,6 +170,11 @@
   "visibilityPublic": "Openbaar — geen aanmelding vereist",
   "visibilityPublicDescription": "Iedereen met de link kan bekijken.",
   "visibilityRequired": "Selecteer een zichtbaarheidsniveau voor deze dataset.",
+  "viewDescription": "Weergavebeschrijving",
+  "viewDescriptionPlaceholder": "Voer een beschrijving in voor deze dataset...",
+  "viewDescriptionDescription": "Optioneel: Beschrijving van deze dataset",
+  "viewHeaderImage": "Weergave headerafbeelding",
+  "viewHeaderImageDescription": "Optioneel: URL voor de header achtergrondafbeelding",
   "yourAccessIsPending": "Uw toegang is in behandeling. Neem contact op met een Guardian Connector-beheerder voor goedkeuring van je account.",
   "yourMapboxStyleDefault": "Mapbox - uw stijl (standaard)"
 }

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -44,6 +44,9 @@
   "dataProvider": "Provedor de dados",
   "dataProviders": "Provedor(es) de dados",
   "dataset": "Conjunto de dados",
+  "datasetTable": "Nome de exibição do conjunto de dados",
+  "datasetTablePlaceholder": "ex., Alertas falsos",
+  "datasetTableDescription": "Opcional: Um nome mais agradável para este conjunto de dados",
   "dateRange": "Período",
   "default": "Padrão",
   "downloadCSV": "Baixar CSV",
@@ -166,6 +169,11 @@
   "visibilityPublic": "Público — sem login necessário",
   "visibilityPublicDescription": "Qualquer pessoa com o link pode ver.",
   "visibilityRequired": "Por favor, selecione um nível de visibilidade para este conjunto de dados.",
+  "viewDescription": "Descrição da visualização",
+  "viewDescriptionPlaceholder": "Digite uma descrição para este conjunto de dados...",
+  "viewDescriptionDescription": "Opcional: Descrição deste conjunto de dados",
+  "viewHeaderImage": "Imagem de cabeçalho da visualização",
+  "viewHeaderImageDescription": "Opcional: URL para a imagem de fundo do cabeçalho",
   "yourAccessIsPending": "Seu acesso está pendente. Entre em contato com um administrador do Guardian Connector para aprovação da conta.",
   "yourMapboxStyleDefault": "Mapbox - seu estilo (padrão)"
 }

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -113,6 +113,9 @@ export const fetchConfig = async (): Promise<Views> => {
         FRONT_END_FILTER_COLUMN: "community",
         MEDIA_BASE_PATH: mediaBasePath,
         ROUTE_LEVEL_PERMISSION: "anyone",
+        DATASET_TABLE: undefined,
+        VIEW_HEADER_IMAGE: undefined,
+        VIEW_DESCRIPTION: undefined,
       },
       bcmform_responses: {
         VIEWS: "map,gallery",
@@ -127,6 +130,9 @@ export const fetchConfig = async (): Promise<Views> => {
         FRONT_END_FILTER_COLUMN: "community",
         MEDIA_BASE_PATH: mediaBasePath,
         ROUTE_LEVEL_PERMISSION: "member",
+        DATASET_TABLE: undefined,
+        VIEW_HEADER_IMAGE: undefined,
+        VIEW_DESCRIPTION: undefined,
       },
       fake_alerts: {
         VIEWS: "alerts",
@@ -142,7 +148,7 @@ export const fetchConfig = async (): Promise<Views> => {
         MAPBOX_ZOOM: 7,
         MAPBOX_PITCH: 0,
         MAPBOX_BEARING: 0,
-        MAPBOX_3D: "NO",
+        MAPBOX_3D: false,
         MAPEO_TABLE: "mapeo_data",
         MAPEO_CATEGORY_IDS: "threat",
         MAP_LEGEND_LAYER_IDS: "road-primary,aerialway",
@@ -150,6 +156,9 @@ export const fetchConfig = async (): Promise<Views> => {
         MAPBOX_ACCESS_TOKEN: mapboxAccessToken,
         PLANET_API_KEY: planetApiKey,
         ROUTE_LEVEL_PERMISSION: "anyone",
+        DATASET_TABLE: undefined,
+        VIEW_HEADER_IMAGE: undefined,
+        VIEW_DESCRIPTION: undefined,
       },
     };
   }

--- a/types/types.ts
+++ b/types/types.ts
@@ -54,6 +54,9 @@ export interface ViewConfig {
   UNWANTED_SUBSTRINGS?: string;
   VIEWS?: string;
   ROUTE_LEVEL_PERMISSION?: RouteLevelPermission; // Who can access this view: anyone, signed-in, member, or admin
+  DATASET_TABLE?: string; // Display name for the dataset/table (e.g., "Fake Alerts" instead of "fake_alerts")
+  VIEW_HEADER_IMAGE?: string; // Image source URL for the dataset card header background
+  VIEW_DESCRIPTION?: string; // Description of the dataset/table
 }
 
 export interface Views {


### PR DESCRIPTION
## Goal

Add three config options for dataset cards: display name, header image, and description. Closes #243 

## Screenshots

<img width="1345" height="791" alt="Screenshot 2025-12-02 at 19 08 21" src="https://github.com/user-attachments/assets/d1e76e8f-7f05-4fb6-8be8-0fbe20ee4bf6" />
<img width="1345" height="791" alt="Screenshot 2025-12-02 at 18 56 50" src="https://github.com/user-attachments/assets/6dc8b8ab-8ed6-423f-b52f-169e2971bea7" />
<img width="1345" height="791" alt="Screenshot 2025-12-02 at 18 54 17" src="https://github.com/user-attachments/assets/ef6c96ab-10ac-4573-99f2-536618f7634f" />

## What I changed and why

1. **Added new config fields** (`types/types.ts`):
   - `DATASET_TABLE` — display name (e.g., "Fake Alerts" instead of "fake_alerts")
   - `VIEW_HEADER_IMAGE` — header background image URL (configurable but not used in index cards)
   - `VIEW_DESCRIPTION` — dataset description text

2. **Created `ConfigDatasetInfo.vue`** — component for editing these fields in the config dashboard, following the pattern of other config components.

3. **Updated `DatasetCard.vue`** — uses `DATASET_TABLE` for the title (falls back to `tableName`) and `VIEW_DESCRIPTION` when available. Removed background image usage from index cards.

4. **Added translations** — added translation keys for all new fields in en, es, pt, nl locale files.

5. **Fixed pre-existing lint error** — changed `MAPBOX_3D` from string `"NO"` to boolean `false` in CI config.

## What I'm not doing here

- Not modifying existing dataset card functionality beyond adding the new fields

## LLM use disclosure

None