### PR TITLE
Improve how we show communityName in AppHeader

### DIFF
--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -5,11 +5,11 @@ import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
 
 const config = useRuntimeConfig();
 const { t } = useI18n();
+
 const communityName = computed(() => {
-  const name = config.public.communityName || "community";
-  // Use i18n to translate community name
-  return t(`community.${name}`) || name;
+  return config.public.communityName || t("community");
 });
+
 const {
   public: { authStrategy },
 } = useRuntimeConfig();


### PR DESCRIPTION
## Goal

I don't think the `community.{communityName}` approach was right for the tab with community name. This PR makes it set `config.public.communityName` else fallback to (localized) "community"