### PR TITLE
Use tablename instead of hard coded `alerts/` for media URL paths

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -76,7 +76,7 @@ export default defineEventHandler(async (event: H3Event) => {
     };
 
     // Prepare alerts data for the alerts view
-    const changeDetectionData = prepareAlertData(mainData);
+    const changeDetectionData = prepareAlertData(mainData, table as string);
     const alertsGeojsonData = {
       mostRecentAlerts: transformToGeojson(
         changeDetectionData.mostRecentAlerts,

--- a/server/dataProcessing/transformData.ts
+++ b/server/dataProcessing/transformData.ts
@@ -235,6 +235,7 @@ const prepareMapData = (
  */
 const prepareAlertData = (
   data: DataEntry[],
+  table: string,
 ): {
   mostRecentAlerts: DataEntry[];
   previousAlerts: DataEntry[];
@@ -307,9 +308,9 @@ const prepareAlertData = (
       satelliteLookup[item.sat_detect_prefix] || item.sat_detect_prefix;
 
     transformedItem["t0_url"] =
-      `alerts/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T0_${item.alert_id}.jpg`;
+      `${table}/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T0_${item.alert_id}.jpg`;
     transformedItem["t1_url"] =
-      `alerts/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T1_${item.alert_id}.jpg`;
+      `${table}/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T1_${item.alert_id}.jpg`;
     transformedItem["previewImagerySource"] =
       satelliteLookup[item.sat_viz_prefix] || item.sat_viz_prefix;
 


### PR DESCRIPTION
## Goal

Image URLs for the alerts dashboard were hardcoded as `alerts/...`. We are now starting to use different table names / paths for alerts datasets. This PR accounts for that by using the table name to construct the URL.