### PR TITLE
Improves Gallery Loading Experience and implements fallback for empty image

### DIFF
--- a/composables/useIntersectionObserver.ts
+++ b/composables/useIntersectionObserver.ts
@@ -1,0 +1,99 @@
+/**
+ * Composable for Intersection Observer API
+ * Provides viewport-based lazy loading functionality
+ *
+ * @param callback - Function called when intersection changes occur
+ * @param options - Optional IntersectionObserver configuration options
+ * @returns Object containing target ref, intersection state, and observer methods
+ */
+export const useIntersectionObserver = (
+  callback: (entries: IntersectionObserverEntry[]) => void,
+  options?: IntersectionObserverInit,
+) => {
+  const target = ref<Element | null>(null);
+  const isIntersecting = ref(false);
+  const hasIntersected = ref(false);
+
+  const defaultOptions: IntersectionObserverInit = {
+    root: null,
+    rootMargin: "50px", // Start loading 50px before entering viewport
+    threshold: 0.01,
+    ...options,
+  };
+
+  let observer: IntersectionObserver | null = null;
+
+  /**
+   * Start observing an element for intersection changes
+   *
+   * @param element - The DOM element to observe
+   */
+  const observe = (element: Element) => {
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      // Fallback for browsers without IntersectionObserver support
+      isIntersecting.value = true;
+      hasIntersected.value = true;
+      callback([
+        {
+          target: element,
+          isIntersecting: true,
+          intersectionRatio: 1,
+          boundingClientRect: element.getBoundingClientRect(),
+          rootBounds: null,
+          time: Date.now(),
+        } as IntersectionObserverEntry,
+      ]);
+      return;
+    }
+
+    observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        isIntersecting.value = entry.isIntersecting;
+        if (entry.isIntersecting && !hasIntersected.value) {
+          hasIntersected.value = true;
+        }
+        callback(entries);
+      });
+    }, defaultOptions);
+
+    observer.observe(element);
+  };
+
+  /**
+   * Stop observing the current target element and disconnect the observer
+   */
+  const unobserve = () => {
+    if (observer && target.value) {
+      observer.unobserve(target.value);
+      observer.disconnect();
+      observer = null;
+    }
+  };
+
+  onMounted(() => {
+    if (target.value) {
+      observe(target.value);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    unobserve();
+  });
+
+  watch(target, (newTarget, oldTarget) => {
+    if (oldTarget && observer) {
+      observer.unobserve(oldTarget);
+    }
+    if (newTarget) {
+      observe(newTarget);
+    }
+  });
+
+  return {
+    target,
+    isIntersecting,
+    hasIntersected,
+    observe,
+    unobserve,
+  };
+};

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -79,6 +79,8 @@
   "iconColumn": "Icon Column",
   "iconColumnDescription": "Optional: Specify a column name (e.g., 'icon') that contains icon filenames (e.g., 'camp.png'). When set and icons base path is configured, point features can be displayed as icons instead of circles.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "If you are zoomed out, alerts will be shown as a",
+  "imageNotFound": "Image not found",
+  "loading": "Loading...",
   "login": "Log in",
   "loginButton": "Sign up or log in",
   "loginError": "An error occurred while trying to log in",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -76,6 +76,8 @@
   "iconColumn": "Columna de Iconos",
   "iconColumnDescription": "Opcional: Especifique un nombre de columna (por ejemplo, 'icon') que contenga nombres de archivos de iconos (por ejemplo, 'camp.png'). Cuando se establece y la ruta base de iconos está configurada, las características de puntos se pueden mostrar como iconos en lugar de círculos.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Si está alejado, las alertas se mostrarán como un",
+  "imageNotFound": "Imagen no encontrada",
+  "loading": "Cargando...",
   "login": "Iniciar sesión",
   "loginButton": "Regístrese o inicie sesión",
   "loginError": "Ocurrió un error al intentar iniciar sesión",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -77,6 +77,8 @@
   "iconColumn": "Icoonkolom",
   "iconColumnDescription": "Optioneel: Specificeer een kolomnaam (bijv. 'icon') die bestandsnamen van iconen bevat (bijv. 'camp.png'). Indien ingesteld en het basispad voor iconen is geconfigureerd, kunnen puntkenmerken worden weergegeven als iconen in plaats van cirkels.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Als u bent uitgezoomd, worden alerts weergegeven als een",
+  "imageNotFound": "Afbeelding niet gevonden",
+  "loading": "Laden...",
   "login": "Log in",
   "loginButton": "Meld u aan of log in",
   "loginError": "Er is een fout opgetreden bij het inloggen",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -76,6 +76,8 @@
   "iconColumn": "Coluna de Ícones",
   "iconColumnDescription": "Opcional: Especifique um nome de coluna (por exemplo, 'icon') que contenha nomes de arquivos de ícones (por exemplo, 'camp.png'). Quando definido e o caminho base dos ícones está configurado, os recursos de pontos podem ser exibidos como ícones em vez de círculos.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Se você estiver afastado, os alertas serão mostrados como um",
+  "imageNotFound": "Imagem não encontrada",
+  "loading": "Carregando...",
   "login": "Faça login",
   "loginButton": "Inscreva-se ou faça login",
   "loginError": "Ocorreu um erro ao tentar fazer login",


### PR DESCRIPTION
## Goal
Improve the gallery image loading experience by implementing true viewport-based lazy loading and better error handling. Images should only load when they're about to enter the viewport, and missing images (404) should display a red X icon instead of showing "Loading" indefinitely. Closes #253 

## Screenshots
<img width="1115" height="314" alt="Screenshot 2025-12-18 at 09 41 15" src="https://github.com/user-attachments/assets/b452710a-8b5a-429a-bcd3-9bf9f91ede6d" />
At first we load a few images
<img width="1115" height="314" alt="Screenshot 2025-12-18 at 09 41 31" src="https://github.com/user-attachments/assets/4e6e6c0e-d112-4c4d-b3f3-e9c21281d4be" />
As we scroll number of images increases from 3 -> 7

## What I changed and why
Implemented viewport-based lazy loading for gallery images and improved error handling. Created a new `useIntersectionObserve`r composable that uses the Intersection Observer API to load images only when they're within 100px of the viewport, replacing the previous approach that loaded all paginated images at once. Updated `MediaFile.vue` to use this composable, added 404 error handling that displays a red X icon instead of a loading state, and added loading placeholders. Added translations for "imageNotFound" and "loading" to all locale files (en, es, pt, nl). These changes reduce initial page load and bandwidth usage, especially for galleries with many images, and provide clearer feedback when images fail to load.

## What I'm not doing here


## LLM use disclosure

Used to research Intersection Observer API

