### PR TITLE
Fixes Noisy oauth middleware stacktrace in Explorer logs

### DIFF
--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -10,7 +10,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     public: { authStrategy },
   } = useRuntimeConfig();
   const router = useRouter();
-  console.log("[TEST] oauth.global middleware called", user, to.path);
+
   // In order to redirect the user back to the page they were on when unauthenticated, we need to store the redirect url in session storage
   // We use the window object to get where the user was before they were redirected to the login page
   // Store it in the session storage and in the Auth0 component we grab and redirect


### PR DESCRIPTION

## Goal
Fix Noisy oauth middleware stacktrace in Explorer logs. closes #281 

## Screenshots


## What I changed and why


## What I'm not doing here


## LLM use disclosure
None