### PR TITLE
Split AlertsDashboard.vue: Refactor Sidebar into useAlertsDateFilter Composable

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { toRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
@@ -24,6 +25,7 @@ import IncidentsSidebar from "@/components/alerts/IncidentsSidebar.vue";
 import IncidentsControls from "@/components/alerts/IncidentsControls.vue";
 import { useIncidents } from "@/composables/useIncidents";
 import { useFeatureSelection } from "@/composables/useFeatureSelection";
+import { useAlertsDateFilter } from "@/composables/useAlertsDateFilter";
 
 import type { Layer, MapMouseEvent } from "mapbox-gl";
 import type {
@@ -136,6 +138,16 @@ const {
   showIntroPanel,
   isMapeo,
 );
+
+// Use alerts date filter composable
+const { filteredData, getDateOptions, handleDateRangeChanged, resetDateRange } =
+  useAlertsDateFilter(
+    map,
+    toRef(props, "alertsData"),
+    toRef(props, "alertsStatistics"),
+    localAlertsData,
+    t,
+  );
 
 /**
  * Selects and zooms to an alert feature based on its ID
@@ -1158,206 +1170,11 @@ const toggleLayerVisibility = (item: MapLegendItem) => {
 // === Sidebar Content ====
 // ========================
 
-const selectedDateRange = ref();
-/**
- * Converts date strings from "MM-YYYY" format to "YYYYMM" format for comparison.
- * If the start or end date is "earlier", it substitutes with the earliest or twelve months before date.
- */
-const convertDates = (start: string, end: string) => {
-  const convertToDate = (dateStr: string) => {
-    const [month, year] = dateStr.split("-").map(Number);
-    return (year * 100 + month).toString();
-  };
-
-  if (start === t("earlier")) {
-    start = props.alertsStatistics.earliestAlertsDate;
-  }
-
-  if (end === t("earlier")) {
-    end = props.alertsStatistics.twelveMonthsBefore;
-  }
-
-  const startDate = convertToDate(start);
-  const endDate = convertToDate(end);
-
-  return [startDate, endDate];
-};
-
-/**
- * Retrieves date options for selection, replacing earlier dates with "Earlier" if there are more than 12 dates.
- * @returns {string[]} - An array of date options.
- */
-const getDateOptions = () => {
-  let dates = props.alertsStatistics.allDates;
-
-  if (dates.length > 12) {
-    const last12Dates = dates.slice(-12);
-    dates = [t("earlier"), ...last12Dates];
-  }
-
-  return dates;
-};
-
-/**
- * Handles changes in the selected date range, updating map layers to show features within the new range.
- * @param {[string, string]} newRange - The new date range as an array of start and end dates.
- */
-const handleDateRangeChanged = (newRange: [string, string]) => {
-  // Extract start and end dates from newRange
-  let [start, end] = newRange;
-
-  if (start === t("earlier")) {
-    start = props.alertsStatistics.earliestAlertsDate;
-  }
-
-  if (end === t("earlier")) {
-    end = props.alertsStatistics.twelveMonthsBefore;
-  }
-
-  // Update the selected date range first so filteredData is computed correctly
-  selectedDateRange.value = newRange;
-
-  // Update the layers to only show features within the selected date range
-  nextTick(() => {
-    // Update source data for all alert sources so clusters reflect filtered data
-    const sourceIds = [
-      "most-recent-alerts-point",
-      "most-recent-alerts-polygon",
-      "most-recent-alerts-linestring",
-      "most-recent-alerts-centroids",
-      "previous-alerts-point",
-      "previous-alerts-polygon",
-      "previous-alerts-linestring",
-      "previous-alerts-centroids",
-    ];
-
-    sourceIds.forEach((sourceId) => {
-      const source = map.value.getSource(sourceId) as mapboxgl.GeoJSONSource;
-      if (!source) return;
-
-      const isMostRecent = sourceId.startsWith("most-recent-alerts");
-      const filteredFeatures = isMostRecent
-        ? filteredData.value.mostRecentAlerts.features
-        : filteredData.value.previousAlerts.features;
-
-      if (sourceId.endsWith("-point")) {
-        // Point source: filter by Point geometry type
-        const pointFeatures = filteredFeatures.filter(
-          (f) => f.geometry.type === "Point",
-        );
-        source.setData({
-          type: "FeatureCollection",
-          features: pointFeatures,
-        });
-      } else if (sourceId.endsWith("-polygon")) {
-        // Polygon source: filter by Polygon/MultiPolygon geometry type
-        const polygonFeatures = filteredFeatures.filter(
-          (f) =>
-            f.geometry.type === "Polygon" || f.geometry.type === "MultiPolygon",
-        );
-        source.setData({
-          type: "FeatureCollection",
-          features: polygonFeatures,
-        });
-      } else if (sourceId.endsWith("-linestring")) {
-        // LineString source: filter by LineString geometry type
-        const linestringFeatures = filteredFeatures.filter(
-          (f) => f.geometry.type === "LineString",
-        );
-        source.setData({
-          type: "FeatureCollection",
-          features: linestringFeatures,
-        });
-      } else if (sourceId.endsWith("-centroids")) {
-        // Centroid source: create Point features from geographicCentroid
-        const centroidFeatures = filteredFeatures
-          .filter(
-            (f) =>
-              f.properties?.geographicCentroid && f.geometry.type !== "Point",
-          )
-          .map((feature) => ({
-            type: "Feature" as const,
-            geometry: {
-              type: "Point" as const,
-              coordinates: feature.properties?.geographicCentroid
-                .split(",")
-                .map(Number)
-                .reverse(),
-            },
-            properties: {
-              ...feature.properties,
-            },
-          }));
-        source.setData({
-          type: "FeatureCollection",
-          features: centroidFeatures,
-        });
-      }
-    });
-
-    // Update layer filters for non-clustered features (still needed for unclustered points/centroids)
-    map.value.getStyle().layers.forEach((layer: Layer) => {
-      if (
-        (layer.id.startsWith("most-recent-alerts") ||
-          layer.id.startsWith("previous-alerts")) &&
-        // Don't apply filters to cluster layers - they don't have feature properties
-        !layer.id.includes("-cluster")
-      ) {
-        // For point and centroid layers, only need cluster exclusion filter
-        // (date filtering is handled by source data update above)
-        if (layer.id.endsWith("-point") || layer.id.endsWith("-centroids")) {
-          map.value.setFilter(layer.id, ["!", ["has", "point_count"]]);
-        } else {
-          // For polygon/linestring layers, remove filters (source data handles filtering)
-          map.value.setFilter(layer.id, null);
-        }
-      }
-    });
-
-    // Update localAlertsData to match the data with the selected date range
-    localAlertsData.value = filteredData.value;
-  });
-};
-
 /* Closes the sidebar and resets the selected feature. */
 const handleSidebarClose = () => {
   showSidebar.value = false;
   resetSelectedFeature();
 };
-
-/**
- * Computes filtered data based on the selected date range.
- * If no date range is selected, returns the full alerts data.
- * @returns {Object} - The filtered alerts data.
- */
-const filteredData = computed(() => {
-  if (!selectedDateRange.value) {
-    return props.alertsData;
-  }
-
-  const [start, end] = selectedDateRange.value;
-  const [startDate, endDate] = convertDates(start, end);
-
-  const filterFeatures = (features: Feature[]) => {
-    return features.filter((feature) => {
-      const monthDetected = feature.properties
-        ? feature.properties["YYYYMM"]
-        : null;
-      return monthDetected >= startDate && monthDetected <= endDate;
-    });
-  };
-
-  return {
-    mostRecentAlerts: {
-      ...props.alertsData.mostRecentAlerts,
-      features: filterFeatures(props.alertsData.mostRecentAlerts.features),
-    },
-    previousAlerts: {
-      ...props.alertsData.previousAlerts,
-      features: filterFeatures(props.alertsData.previousAlerts.features),
-    },
-  };
-});
 
 // ===========================================
 // === Methods for selecting and resetting ===
@@ -1374,7 +1191,7 @@ const resetToInitialState = () => {
   showIntroPanel.value = true;
   imageUrl.value = [];
   imageCaption.value = null;
-  selectedDateRange.value = null;
+  resetDateRange();
 
   // Reset source data for all alert sources to original data
   const sourceIds = [

--- a/composables/useAlertsDateFilter.ts
+++ b/composables/useAlertsDateFilter.ts
@@ -1,0 +1,230 @@
+import { computed, nextTick, ref, type Ref, type ComputedRef } from "vue";
+import type mapboxgl from "mapbox-gl";
+import type { Feature } from "geojson";
+import type { AlertsData, AlertsStatistics } from "@/types/types";
+
+/**
+ * Composable for managing alerts date range filtering.
+ * Handles date range selection, filtering alerts data, and updating map sources.
+ */
+export function useAlertsDateFilter(
+  map: Ref<mapboxgl.Map | undefined>,
+  alertsData: Ref<AlertsData>,
+  alertsStatistics: Ref<AlertsStatistics>,
+  localAlertsData: Ref<Feature | AlertsData>,
+  t: (key: string) => string,
+) {
+  const selectedDateRange = ref<[string, string] | undefined>();
+
+  /**
+   * Converts date strings from "MM-YYYY" format to "YYYYMM" format for comparison.
+   * If the start or end date is "earlier", it substitutes with the earliest or twelve months before date.
+   */
+  const convertDates = (start: string, end: string) => {
+    const convertToDate = (dateStr: string) => {
+      const [month, year] = dateStr.split("-").map(Number);
+      return (year * 100 + month).toString();
+    };
+
+    if (start === t("earlier")) {
+      start = alertsStatistics.value.earliestAlertsDate;
+    }
+
+    if (end === t("earlier")) {
+      end = alertsStatistics.value.twelveMonthsBefore;
+    }
+
+    const startDate = convertToDate(start);
+    const endDate = convertToDate(end);
+
+    return [startDate, endDate];
+  };
+
+  /**
+   * Retrieves date options for selection, replacing earlier dates with "Earlier" if there are more than 12 dates.
+   * @returns {string[]} - An array of date options.
+   */
+  const getDateOptions = () => {
+    let dates = alertsStatistics.value.allDates;
+
+    if (dates.length > 12) {
+      const last12Dates = dates.slice(-12);
+      dates = [t("earlier"), ...last12Dates];
+    }
+
+    return dates;
+  };
+
+  /**
+   * Computes filtered data based on the selected date range.
+   * If no date range is selected, returns the full alerts data.
+   * @returns {Object} - The filtered alerts data.
+   */
+  const filteredData: ComputedRef<AlertsData> = computed(() => {
+    if (!selectedDateRange.value) {
+      return alertsData.value;
+    }
+
+    const [start, end] = selectedDateRange.value;
+    const [startDate, endDate] = convertDates(start, end);
+
+    const filterFeatures = (features: Feature[]) => {
+      return features.filter((feature) => {
+        const monthDetected = feature.properties
+          ? feature.properties["YYYYMM"]
+          : null;
+        return monthDetected >= startDate && monthDetected <= endDate;
+      });
+    };
+
+    return {
+      mostRecentAlerts: {
+        ...alertsData.value.mostRecentAlerts,
+        features: filterFeatures(alertsData.value.mostRecentAlerts.features),
+      },
+      previousAlerts: {
+        ...alertsData.value.previousAlerts,
+        features: filterFeatures(alertsData.value.previousAlerts.features),
+      },
+    };
+  });
+
+  /**
+   * Handles changes in the selected date range, updating map layers to show features within the new range.
+   * @param {[string, string]} newRange - The new date range as an array of start and end dates.
+   */
+  const handleDateRangeChanged = (newRange: [string, string]) => {
+    // Extract start and end dates from newRange
+    let [start, end] = newRange;
+
+    if (start === t("earlier")) {
+      start = alertsStatistics.value.earliestAlertsDate;
+    }
+
+    if (end === t("earlier")) {
+      end = alertsStatistics.value.twelveMonthsBefore;
+    }
+
+    // Update the selected date range first so filteredData is computed correctly
+    selectedDateRange.value = newRange;
+
+    // Update the layers to only show features within the selected date range
+    nextTick(() => {
+      if (!map.value) return;
+
+      // Update source data for all alert sources so clusters reflect filtered data
+      const sourceIds = [
+        "most-recent-alerts-point",
+        "most-recent-alerts-polygon",
+        "most-recent-alerts-linestring",
+        "most-recent-alerts-centroids",
+        "previous-alerts-point",
+        "previous-alerts-polygon",
+        "previous-alerts-linestring",
+        "previous-alerts-centroids",
+      ];
+
+      sourceIds.forEach((sourceId) => {
+        const source = map.value!.getSource(sourceId) as mapboxgl.GeoJSONSource;
+        if (!source) return;
+
+        const isMostRecent = sourceId.startsWith("most-recent-alerts");
+        const filteredFeatures = isMostRecent
+          ? filteredData.value.mostRecentAlerts.features
+          : filteredData.value.previousAlerts.features;
+
+        if (sourceId.endsWith("-point")) {
+          // Point source: filter by Point geometry type
+          const pointFeatures = filteredFeatures.filter(
+            (f) => f.geometry.type === "Point",
+          );
+          source.setData({
+            type: "FeatureCollection",
+            features: pointFeatures,
+          });
+        } else if (sourceId.endsWith("-polygon")) {
+          // Polygon source: filter by Polygon/MultiPolygon geometry type
+          const polygonFeatures = filteredFeatures.filter(
+            (f) =>
+              f.geometry.type === "Polygon" ||
+              f.geometry.type === "MultiPolygon",
+          );
+          source.setData({
+            type: "FeatureCollection",
+            features: polygonFeatures,
+          });
+        } else if (sourceId.endsWith("-linestring")) {
+          // LineString source: filter by LineString geometry type
+          const linestringFeatures = filteredFeatures.filter(
+            (f) => f.geometry.type === "LineString",
+          );
+          source.setData({
+            type: "FeatureCollection",
+            features: linestringFeatures,
+          });
+        } else if (sourceId.endsWith("-centroids")) {
+          // Centroid source: create Point features from geographicCentroid
+          const centroidFeatures = filteredFeatures
+            .filter(
+              (f) =>
+                f.properties?.geographicCentroid && f.geometry.type !== "Point",
+            )
+            .map((feature) => ({
+              type: "Feature" as const,
+              geometry: {
+                type: "Point" as const,
+                coordinates: feature.properties?.geographicCentroid
+                  .split(",")
+                  .map(Number)
+                  .reverse(),
+              },
+              properties: {
+                ...feature.properties,
+              },
+            }));
+          source.setData({
+            type: "FeatureCollection",
+            features: centroidFeatures,
+          });
+        }
+      });
+
+      // Update layer filters for non-clustered features (still needed for unclustered points/centroids)
+      map.value.getStyle().layers.forEach((layer) => {
+        if (
+          (layer.id.startsWith("most-recent-alerts") ||
+            layer.id.startsWith("previous-alerts")) &&
+          // Don't apply filters to cluster layers - they don't have feature properties
+          !layer.id.includes("-cluster")
+        ) {
+          // For point and centroid layers, only need cluster exclusion filter
+          // (date filtering is handled by source data update above)
+          if (layer.id.endsWith("-point") || layer.id.endsWith("-centroids")) {
+            map.value!.setFilter(layer.id, ["!", ["has", "point_count"]]);
+          } else {
+            // For polygon/linestring layers, remove filters (source data handles filtering)
+            map.value!.setFilter(layer.id, null);
+          }
+        }
+      });
+
+      // Update localAlertsData to match the data with the selected date range
+      localAlertsData.value = filteredData.value;
+    });
+  };
+
+  /**
+   * Resets the selected date range to null.
+   */
+  const resetDateRange = () => {
+    selectedDateRange.value = undefined;
+  };
+
+  return {
+    selectedDateRange,
+    filteredData,
+    getDateOptions,
+    handleDateRangeChanged,
+    resetDateRange,
+  };
+}


### PR DESCRIPTION


## Goal
Part of our efforts to slim down the AlertsDashboard, this PR moves the logic for the sidebar (on the left) into it's own composable.

## Screenshots
<img width="1466" height="829" alt="Screenshot 2026-01-29 at 16 54 20" src="https://github.com/user-attachments/assets/0c398e9a-c61a-4482-b1f0-bbbb12d18d93" />
<img width="1466" height="829" alt="Screenshot 2026-01-29 at 16 53 00" src="https://github.com/user-attachments/assets/8d3a8deb-db1d-4ff1-8940-8fd384ae1991" />
<img width="1466" height="829" alt="Screenshot 2026-01-29 at 16 52 56" src="https://github.com/user-attachments/assets/15f9a5a3-8888-4474-b273-1150891e8542" />
<img width="405" height="829" alt="Screenshot 2026-01-29 at 16 52 41" src="https://github.com/user-attachments/assets/a1ad200d-e91f-4ce6-976d-3e79c893cb2f" />


## What I changed and why
Moved sidebar into its own composable.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
