### PR TITLE
Reverse incident list ordering to show most recent first

### DIFF
--- a/server/database/annotatedCollections.ts
+++ b/server/database/annotatedCollections.ts
@@ -1,4 +1,4 @@
-import { sql, eq, and } from "drizzle-orm";
+import { sql, eq, and, desc } from "drizzle-orm";
 import type {
   AnnotatedCollection,
   Incident,
@@ -362,7 +362,7 @@ export const listAnnotatedCollections = async (filters?: {
       .from(annotatedCollections)
       .leftJoin(incidents, eq(annotatedCollections.id, incidents.collectionId))
       .where(eq(incidents.status, filters.status))
-      .orderBy(annotatedCollections.createdAt)
+      .orderBy(desc(annotatedCollections.createdAt))
       .limit(filters?.limit || 20)
       .offset(filters?.offset || 0);
 
@@ -402,7 +402,7 @@ export const listAnnotatedCollections = async (filters?: {
       .select()
       .from(annotatedCollections)
       .where(whereCondition)
-      .orderBy(annotatedCollections.createdAt)
+      .orderBy(desc(annotatedCollections.createdAt))
       .limit(filters?.limit || 20)
       .offset(filters?.offset || 0);
 


### PR DESCRIPTION

## Goal
Per Mayana's feedback this PR shows the most recent incidents first in the list. Closes #294 

## Screenshots

<img width="418" height="832" alt="Screenshot 2026-02-02 at 10 32 57" src="https://github.com/user-attachments/assets/de5288ff-1407-45e5-a10c-7ec1a0162f87" />

## What I changed and why
Simple backend change to sort by `created_at`.

## What I'm not doing here


## LLM use disclosure
None