### PR TITLE
Prevent creating incidents without selected alerts

### DIFF
--- a/components/alerts/IncidentsSidebar.vue
+++ b/components/alerts/IncidentsSidebar.vue
@@ -137,6 +137,10 @@ const handleSubmit = () => {
   if (!formData.value.name.trim()) {
     return;
   }
+  // Prevent creating an incident without selected alerts (no entries)
+  if (props.selectedSources.length === 0) {
+    return;
+  }
 
   emit("createIncident", {
     name: formData.value.name,
@@ -438,7 +442,11 @@ const handleClose = () => {
             </div>
 
             <div class="form-actions">
-              <button type="submit" :disabled="isCreating" class="submit-btn">
+              <button
+                type="submit"
+                :disabled="isCreating || selectedSources.length === 0"
+                class="submit-btn"
+              >
                 {{
                   isCreating
                     ? $t("incidents.creating")

--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -261,6 +261,11 @@ export const useIncidents = (
     impact_description?: string;
     supporting_evidence?: Record<string, unknown>;
   }) => {
+    if (selectedSources.value.length === 0) {
+      throw new Error(
+        "Cannot create incident without selected alerts. Select at least one alert.",
+      );
+    }
     isCreatingIncident.value = true;
     try {
       const response = await $fetch<{ incident: AnnotatedCollection }>(


### PR DESCRIPTION
## Goal
Ensure that we cannot create "empty" Incidents i.e. Incidents with no selected sources. Closes #296 

## Screenshots


## What I changed and why
 incidents with no entries cannot be created via UI or API call. Disable Create Incident submit button when selectedSources is empty. Block form submission in handleSubmit when no sources selected. Guard in useIncidents createIncident: throw if selectedSources empty


## What I'm not doing here


## LLM use disclosure
