### PR TITLE
Move filtering and presentation transforms to client

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,17 +1,4 @@
-import murmurhash from "murmurhash";
-
 import { fetchConfig, fetchData } from "@/server/database/dbOperations";
-import {
-  prepareAlertData,
-  prepareAlertsStatistics,
-  transformToGeojson,
-  prepareMapData,
-  transformSurveyData,
-} from "@/server/dataProcessing/transformData";
-import {
-  filterUnwantedKeys,
-  filterGeoData,
-} from "@/server/dataProcessing/filterData";
 import { validatePermissions } from "@/utils/auth";
 
 import type { H3Event } from "h3";
@@ -23,35 +10,11 @@ import type {
 import { parseBasemaps } from "@/server/utils/basemaps";
 
 /**
- * Converts a Mapeo document ID (64-bit hex string) to a 32-bit integer
- * using MurmurHash for Mapbox feature state management. This is a lossy, non-reversible operation.
+ * GET /api/[table]/alerts
  *
- * Mapbox requires feature IDs to be either a Number or a string that can be safely
- * cast to a Number, but Mapeo IDs are 64-bit hex strings that exceed JavaScript's
- * safe integer range. This function uses MurmurHash to generate a 32-bit integer
- * from the 64-bit hex string, ensuring compatibility with Mapbox.
- *
- * Reference: https://stackoverflow.com/questions/72040370/why-are-my-dataset-features-ids-undefined-in-mapbox-gl-while-i-have-set-them
- *
- * @param {string} mapeoId - The Mapeo document ID as a 16-character hex string (e.g., "0084cdc57c0b0280")
- * @returns {number} - A 32-bit integer for use with Mapbox feature state management
- * @throws {Error} - If the input is not a valid 16-character hex string
+ * Returns raw alert data, metadata, and configuration. Filtering and presentation
+ * transformations are applied on the client (see subissue #269).
  */
-const generateMapboxIdFromMapeoFeatureId = (mapeoId: string): number => {
-  // Validate that this is actually a Mapeo ID format
-  if (
-    !mapeoId ||
-    typeof mapeoId !== "string" ||
-    !mapeoId.match(/^[0-9a-fA-F]{16}$/)
-  ) {
-    throw new Error(
-      `Invalid Mapeo ID format: ${mapeoId}. Expected 16-character hex string.`,
-    );
-  }
-
-  return murmurhash.v3(mapeoId);
-};
-
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
 
@@ -64,10 +27,7 @@ export default defineEventHandler(async (event: H3Event) => {
   try {
     const viewsConfig = await fetchConfig();
 
-    // Check visibility permissions
     const permission = viewsConfig[table]?.ROUTE_LEVEL_PERMISSION ?? "member";
-
-    // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
     const { mainData, metadata } = (await fetchData(table)) as {
@@ -75,81 +35,23 @@ export default defineEventHandler(async (event: H3Event) => {
       metadata: AlertsMetadata[];
     };
 
-    // Prepare alerts data for the alerts view
-    const changeDetectionData = prepareAlertData(mainData, table as string);
-    const alertsGeojsonData = {
-      mostRecentAlerts: transformToGeojson(
-        changeDetectionData.mostRecentAlerts,
-      ),
-      previousAlerts: transformToGeojson(changeDetectionData.previousAlerts),
-    };
-
-    // Prepare Mapeo data for the alerts view
+    let mapeoRawData: DataEntry[] | null = null;
+    let mapeoColumns: unknown = null;
     const mapeoTable = viewsConfig[table].MAPEO_TABLE;
     const mapeoCategoryIds = viewsConfig[table].MAPEO_CATEGORY_IDS;
 
-    let mapeoData = null;
-
     if (mapeoTable && mapeoCategoryIds) {
-      // Fetch Mapeo data
-      const rawMapeoData = await fetchData(mapeoTable);
-
-      // Filter data to remove unwanted columns and substrings
-      const filteredMapeoData = filterUnwantedKeys(
-        rawMapeoData.mainData,
-        rawMapeoData.columnsData,
-        viewsConfig[table].UNWANTED_COLUMNS,
-        viewsConfig[table].UNWANTED_SUBSTRINGS,
-      );
-
-      // Filter Mapeo data to only show data where category matches any values in mapeoCategoryIds (a comma-separated string of values)
-      const filteredMapeoDataByCategory = filteredMapeoData.filter(
-        (row: DataEntry) => {
-          return Object.keys(row).some(
-            (key) =>
-              key.includes("category") &&
-              mapeoCategoryIds.split(",").includes(row[key]),
-          );
-        },
-      );
-
-      // Filter only data with valid geofields
-      const filteredMapeoGeoData = filterGeoData(filteredMapeoDataByCategory);
-      // Transform data that was collected using survey apps (e.g. KoBoToolbox, Mapeo)
-      const transformedMapeoData = transformSurveyData(filteredMapeoGeoData);
-      // Process geodata
-      const processedMapeoData = prepareMapData(
-        transformedMapeoData,
-        viewsConfig[table].FRONT_END_FILTER_COLUMN,
-      );
-
-      // Add normalized IDs for Mapeo features to ensure Mapbox compatibility
-      // This is done here because we know we're dealing with Mapeo data specifically
-      const mapeoDataWithNormalizedIds = processedMapeoData.map((item) => {
-        if (
-          item.id &&
-          typeof item.id === "string" &&
-          item.id.match(/^[0-9a-fA-F]{16}$/)
-        ) {
-          item.normalizedId = generateMapboxIdFromMapeoFeatureId(item.id);
-        }
-        return item;
-      });
-
-      mapeoData = mapeoDataWithNormalizedIds;
+      const rawMapeo = await fetchData(mapeoTable);
+      mapeoRawData = rawMapeo.mainData;
+      mapeoColumns = rawMapeo.columnsData;
     }
 
-    // Prepare statistics data for the alerts view
-    const alertsStatistics = prepareAlertsStatistics(mainData, metadata);
-
-    // Parse basemaps configuration
     const { basemaps, defaultMapboxStyle } = parseBasemaps(viewsConfig, table);
 
-    const response = {
-      alertsData: alertsGeojsonData,
-      alertsStatistics: alertsStatistics,
+    return {
       allowedFileExtensions: allowedFileExtensions,
       logoUrl: viewsConfig[table].LOGO_URL,
+      mainData,
       mapLegendLayerIds: viewsConfig[table].MAP_LEGEND_LAYER_IDS,
       mapbox3d: viewsConfig[table].MAPBOX_3D ?? false,
       mapbox3dTerrainExaggeration: Number(
@@ -164,15 +66,20 @@ export default defineEventHandler(async (event: H3Event) => {
       mapboxStyle: defaultMapboxStyle,
       mapboxBasemaps: basemaps,
       mapboxZoom: Number(viewsConfig[table].MAPBOX_ZOOM),
-      mapeoData: mapeoData,
+      mapeoCategoryIds: mapeoCategoryIds ?? null,
+      mapeoColumns,
+      mapeoData: mapeoRawData,
+      mapeoTable: mapeoTable ?? null,
       mediaBasePath: viewsConfig[table].MEDIA_BASE_PATH,
       mediaBasePathAlerts: viewsConfig[table].MEDIA_BASE_PATH_ALERTS,
+      metadata,
       planetApiKey: viewsConfig[table].PLANET_API_KEY,
       table: table,
       routeLevelPermission: viewsConfig[table].ROUTE_LEVEL_PERMISSION,
+      unwantedColumns: viewsConfig[table].UNWANTED_COLUMNS,
+      unwantedSubstrings: viewsConfig[table].UNWANTED_SUBSTRINGS,
+      filterColumn: viewsConfig[table].FRONT_END_FILTER_COLUMN,
     };
-
-    return response;
   } catch (error) {
     if (error instanceof Error) {
       console.error("Error fetching data on API side:", error.message);

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -1,20 +1,16 @@
 import { fetchConfig, fetchData } from "@/server/database/dbOperations";
-import {
-  prepareMapData,
-  prepareMapStatistics,
-  transformSurveyData,
-} from "@/server/dataProcessing/transformData";
-import {
-  filterUnwantedKeys,
-  filterOutUnwantedValues,
-  filterGeoData,
-} from "@/server/dataProcessing/filterData";
 import { validatePermissions } from "@/utils/auth";
 
 import type { H3Event } from "h3";
-import type { AllowedFileExtensions, ColumnEntry } from "@/types/types";
+import type { AllowedFileExtensions } from "@/types/types";
 import { parseBasemaps } from "@/server/utils/basemaps";
 
+/**
+ * GET /api/[table]/map
+ *
+ * Returns raw data and configuration. Filtering and presentation transformations
+ * are applied on the client (see subissue #269).
+ */
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
 
@@ -27,54 +23,21 @@ export default defineEventHandler(async (event: H3Event) => {
   try {
     const viewsConfig = await fetchConfig();
 
-    // Check visibility permissions
     const permission = viewsConfig[table]?.ROUTE_LEVEL_PERMISSION ?? "member";
-
-    // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
     const { mainData, columnsData } = await fetchData(table);
 
-    // Filter data to remove unwanted columns and substrings
-    const filteredData = filterUnwantedKeys(
-      mainData,
-      columnsData as ColumnEntry[],
-      viewsConfig[table].UNWANTED_COLUMNS,
-      viewsConfig[table].UNWANTED_SUBSTRINGS,
-    );
-    // Filter data to remove unwanted values per chosen column
-    const dataFilteredByValues = filterOutUnwantedValues(
-      filteredData,
-      viewsConfig[table].FILTER_BY_COLUMN,
-      viewsConfig[table].FILTER_OUT_VALUES_FROM_COLUMN,
-    );
-    // Filter only data with valid geofields
-    const filteredGeoData = filterGeoData(dataFilteredByValues);
-    // Transform data that was collected using survey apps (e.g. KoBoToolbox, Mapeo)
-    const transformedData = transformSurveyData(
-      filteredGeoData,
-      viewsConfig[table].ICON_COLUMN,
-    );
-    // Process geodata
-    const processedGeoData = prepareMapData(
-      transformedData,
-      viewsConfig[table].FRONT_END_FILTER_COLUMN,
-    );
-
-    // Prepare statistics data for the map view
-    const mapStatistics = prepareMapStatistics(processedGeoData);
-
-    // Parse basemaps configuration
     const { basemaps, defaultMapboxStyle } = parseBasemaps(viewsConfig, table);
 
-    const response = {
+    return {
       allowedFileExtensions: allowedFileExtensions,
       colorColumn: viewsConfig[table].COLOR_COLUMN,
-      data: processedGeoData,
+      columns: columnsData,
+      data: mainData,
       filterColumn: viewsConfig[table].FRONT_END_FILTER_COLUMN,
       iconColumn: viewsConfig[table].ICON_COLUMN,
       mapLegendLayerIds: viewsConfig[table].MAP_LEGEND_LAYER_IDS,
-      mapStatistics: mapStatistics,
       mapbox3d: viewsConfig[table].MAPBOX_3D ?? false,
       mapbox3dTerrainExaggeration: Number(
         viewsConfig[table].MAPBOX_3D_TERRAIN_EXAGGERATION,
@@ -94,9 +57,12 @@ export default defineEventHandler(async (event: H3Event) => {
       planetApiKey: viewsConfig[table].PLANET_API_KEY,
       table: table,
       routeLevelPermission: viewsConfig[table].ROUTE_LEVEL_PERMISSION,
+      unwantedColumns: viewsConfig[table].UNWANTED_COLUMNS,
+      unwantedSubstrings: viewsConfig[table].UNWANTED_SUBSTRINGS,
+      filterByColumn: viewsConfig[table].FILTER_BY_COLUMN,
+      filterOutValuesFromColumn:
+        viewsConfig[table].FILTER_OUT_VALUES_FROM_COLUMN,
     };
-
-    return response;
   } catch (error) {
     if (error instanceof Error) {
       console.error("Error fetching data on API side:", error.message);

--- a/test/dataProcessing/filterData.test.ts
+++ b/test/dataProcessing/filterData.test.ts
@@ -5,7 +5,7 @@ import {
   filterOutUnwantedValues,
   filterGeoData,
   filterDataByExtension,
-} from "@/server/dataProcessing/filterData";
+} from "@/utils/dataProcessing/filterData";
 import { mapeoData } from "../fixtures/mapeoData";
 
 describe("filterUnwantedKeys", () => {

--- a/test/dataProcessing/helpers.test.ts
+++ b/test/dataProcessing/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { calculateCentroid } from "@/server/dataProcessing/helpers";
+import { calculateCentroid } from "@/utils/dataProcessing/helpers";
 
 describe("calculateCentroid", () => {
   it("returns centroid for Point", () => {

--- a/test/dataProcessing/transformData.test.ts
+++ b/test/dataProcessing/transformData.test.ts
@@ -9,8 +9,8 @@ import {
   prepareAlertsStatistics,
   prepareMapStatistics,
   transformToGeojson,
-} from "@/server/dataProcessing/transformData";
-import { isValidCoordinate } from "@/server/dataProcessing/helpers";
+} from "@/utils/dataProcessing/transformData";
+import { isValidCoordinate } from "@/utils/dataProcessing/helpers";
 import { mapeoData, transformedMapeoData } from "../fixtures/mapeoData";
 import { alertsData, alertsMetadata } from "../fixtures/alertsData";
 

--- a/utils/dataProcessing/filterData.ts
+++ b/utils/dataProcessing/filterData.ts
@@ -8,24 +8,6 @@ import type {
 
 /**
  * Filters out unwanted columns and substrings from the provided data entries.
- *
- * This function utilizes SQL column mapping if available to determine which columns
- * should be excluded from the dataset. It processes the data based on a list of unwanted
- * column names and substrings, which can be specified as comma-separated strings.
- *
- * @param {DataEntry[]} data - The dataset to be filtered, represented as an array of data entries.
- * @param {ColumnEntry[] | null} columns - An optional array of column entries that provide
- *                                         a mapping between original column names and their
- *                                         corresponding SQL column names. If null, filtering
- *                                         is based on the keys of the data entries.
- * @param {string | undefined} unwantedColumnsList - A comma-separated string of column names
- *                                                   that should be removed from the dataset.
- * @param {string | undefined} unwantedSubstringsList - A comma-separated string of substrings.
- *                                                      Any column name containing one of these
- *                                                      substrings will be removed from the dataset.
- *
- * @returns {DataEntry[]} - A new array of data entries with the unwanted columns and substrings
- *                          filtered out.
  */
 export const filterUnwantedKeys = (
   data: DataEntry[],
@@ -56,7 +38,7 @@ export const filterUnwantedKeys = (
 
   let filteredSqlColumns: Set<string>;
 
-  if (columns) {
+  if (columns && columns.length > 0) {
     const columnMapping: { [key: string]: string } = {};
     columns.forEach((column) => {
       columnMapping[column.original_column] = column.sql_column;
@@ -80,7 +62,7 @@ export const filterUnwantedKeys = (
         (sqlColumn) => !unwantedSqlColumns.has(sqlColumn),
       ),
     );
-  } else {
+  } else if (data.length > 0) {
     filteredSqlColumns = new Set(
       Object.keys(data[0]).filter(
         (key) =>
@@ -88,6 +70,8 @@ export const filterUnwantedKeys = (
           !unwantedSubstrings.some((sub) => key.includes(sub)),
       ),
     );
+  } else {
+    return [];
   }
 
   const filteredData = data.map((item) =>

--- a/utils/dataProcessing/helpers.ts
+++ b/utils/dataProcessing/helpers.ts
@@ -1,3 +1,5 @@
+import murmurhash from "murmurhash";
+
 /** Generates a random hex color code. */
 export const getRandomColor = () => {
   const letters = "0123456789ABCDEF";
@@ -148,4 +150,21 @@ export const formatDate = (date: string): string => {
     ).toLocaleDateString();
   }
   return date;
+};
+
+/**
+ * Converts a Mapeo document ID (64-bit hex string) to a 32-bit integer
+ * using MurmurHash for Mapbox feature state management.
+ */
+export const generateMapboxIdFromMapeoFeatureId = (mapeoId: string): number => {
+  if (
+    !mapeoId ||
+    typeof mapeoId !== "string" ||
+    !mapeoId.match(/^[0-9a-fA-F]{16}$/)
+  ) {
+    throw new Error(
+      `Invalid Mapeo ID format: ${mapeoId}. Expected 16-character hex string.`,
+    );
+  }
+  return murmurhash.v3(mapeoId);
 };

--- a/utils/dataProcessing/transformData.ts
+++ b/utils/dataProcessing/transformData.ts
@@ -22,33 +22,12 @@ import type {
   DataEntry,
 } from "@/types/types";
 
-/**
- * Transforms survey data by modifying keys and values to a more readable format.
- *
- * This function processes an array of survey data entries, transforming both the keys
- * and values of each entry to enhance readability and consistency. The transformation
- * includes:
- * - Modifying key names by removing prefixes, replacing underscores with spaces, and
- *   standardizing certain key names (e.g., "today" becomes "dataCollectedOn").
- * - Adjusting value formats by replacing underscores and semicolons with spaces and commas,
- *   respectively, capitalizing the first letter, and formatting date-related values.
- * - Handling lists enclosed in square brackets by removing brackets and quotes, and
- *   joining items with commas.
- *
- * @param {DataEntry[]} data - An array of survey data entries to be transformed.
- * @param {string} iconColumn - Optional icon column name to exclude from transformation
- * @returns {DataEntry[]} - A new array of data entries with transformed keys and values.
- */
 const transformSurveyData = (
   data: DataEntry[],
   iconColumn?: string,
 ): DataEntry[] => {
   const transformSurveyDataKey = (key: string): string => {
-    // Don't transform the icon column key
-    if (iconColumn && key === iconColumn) {
-      return key;
-    }
-
+    if (iconColumn && key === iconColumn) return key;
     let transformedKey = key
       .replace(/^g__/, "geo")
       .replace(/^p__/, "")
@@ -69,9 +48,7 @@ const transformSurveyData = (
   ) => {
     if (value === null) return null;
     if (key === "g__coordinates") return value;
-    // Don't transform icon column values (filenames)
     if (iconColumn && key === iconColumn) return value;
-
     let transformedValue = value;
     if (typeof transformedValue === "string") {
       transformedValue = transformedValue
@@ -80,20 +57,9 @@ const transformSurveyData = (
       if (key.toLowerCase().includes("category")) {
         transformedValue = transformedValue.replace(/-/g, " ");
       }
-      // TODO: For now this is a quick fix to ensure original timestamps are
-      // returned in file downloads. We need to rethink how we do data transformations
-      // so that file downloads return the original records, not transformed ones.
-      // if (
-      //   key.toLowerCase().includes("created") ||
-      //   key.toLowerCase().includes("modified") ||
-      //   key.toLowerCase().includes("updated")
-      // ) {
-      //   transformedValue = formatDate(transformedValue);
-      // }
       transformedValue =
         transformedValue.charAt(0).toUpperCase() + transformedValue.slice(1);
     }
-    // Handle lists enclosed in square brackets
     if (
       typeof transformedValue === "string" &&
       transformedValue.match(/^\[.*\]$/)
@@ -106,10 +72,10 @@ const transformSurveyData = (
     }
     return transformedValue;
   };
-  const transformedData = data.map((entry) => {
+
+  return data.map((entry) => {
     const transformedEntry: DataEntry = {};
     Object.entries(entry).forEach(([key, value]) => {
-      // Use original key for icon column, don't transform it
       const transformedKey =
         iconColumn && key === iconColumn ? key : transformSurveyDataKey(key);
       const transformedValue = transformSurveyDataValue(key, value);
@@ -119,31 +85,8 @@ const transformSurveyData = (
     });
     return transformedEntry;
   });
-
-  return transformedData;
 };
 
-/**
- * Prepares and processes geospatial data for visualization on a map view.
- *
- * This function takes an array of data entries and an optional filter column,
- * and processes each entry to ensure it is ready for map visualization. It handles
- * the following tasks:
- *
- * 1. Determines the geometry type (Point, LineString, or Polygon) for each entry
- *    based on its coordinates and assigns it if not already specified.
- * 2. Parses and formats geocoordinates from string to JSON format suitable for
- *    map rendering.
- * 3. Assigns a unique color to each entry based on the specified filter column,
- *    ensuring consistent coloring for entries with the same filter value.
- *
- * @param {DataEntry[]} data - An array of data entries, where each entry is an object
- *                             containing geospatial information and other attributes.
- * @param {string | undefined} filterColumn - An optional column name used to filter
- *                                            and assign colors to data entries.
- * @returns {DataEntry[]} - An array of processed data entries, each with formatted
- *                          geocoordinates and assigned colors for map visualization.
- */
 const prepareMapData = (
   data: DataEntry[],
   filterColumn: string | undefined,
@@ -157,7 +100,6 @@ const prepareMapData = (
     try {
       const geometryType = obj.geotype;
       let coordinates: Position | LineString | Polygon = [];
-
       if (!Array.isArray(obj.geocoordinates)) {
         coordinates = JSON.parse(obj.geocoordinates);
       } else {
@@ -199,54 +141,27 @@ const prepareMapData = (
         }
       }
     }
-
     const filterColumnValue =
       filterColumn !== undefined ? (item[filterColumn] ?? "") : "";
     if (filterColumnValue && !colorMap.has(filterColumnValue)) {
       colorMap.set(filterColumnValue, getRandomColor());
     }
     item["filter-color"] = colorMap.get(filterColumnValue) ?? "#3333FF";
-
     return processGeolocation(item);
   });
 
   return processedGeoData;
 };
 
-/**
- * Prepares and transforms alert data for display in the alerts view.
- *
- * This function processes a list of alert data entries, transforming each entry
- * to include only relevant information for display. It segregates the data into
- * two categories: the most recent alerts and previous alerts, based on the latest
- * detection date found in the data.
- *
- * The transformation includes:
- * - Filtering and retaining columns that start with 'g__'.
- * - Mapping satellite prefixes to their full names.
- * - Formatting and capitalizing specific fields such as territory name and data provider.
- * - Calculating geographic centroids for alert locations.
- * - Constructing URLs for alert imagery.
- *
- * @param {DataEntry[]} data - An array of data entries representing alerts.
- * @returns {Object} An object containing two arrays:
- *   - `mostRecentAlerts`: Alerts detected in the most recent month.
- *   - `previousAlerts`: Alerts detected in months prior to the most recent.
- */
 const prepareAlertData = (
   data: DataEntry[],
   table: string,
-): {
-  mostRecentAlerts: DataEntry[];
-  previousAlerts: DataEntry[];
-} => {
+): { mostRecentAlerts: DataEntry[]; previousAlerts: DataEntry[] } => {
   const transformChangeDetectionItem = (
     item: DataEntry,
     formattedMonth?: string,
   ): DataEntry => {
     const transformedItem: DataEntry = {};
-
-    // Keep columns starting with 'g__'
     Object.keys(item).forEach((key) => {
       if (key.startsWith("g__")) {
         transformedItem[key] = item[key];
@@ -269,7 +184,6 @@ const prepareAlertData = (
       return transformedItem;
     }
 
-    // To rewrite the satellite prefix column
     const satelliteLookup: { [key: string]: string } = {
       S1: "Sentinel-1",
       S2: "Sentinel-2",
@@ -283,7 +197,6 @@ const prepareAlertData = (
       IK: "IKONOS",
     };
 
-    // Include only the transformed columns
     transformedItem["territory"] = capitalizeFirstLetter(
       item.territory_name ?? "",
     );
@@ -306,20 +219,17 @@ const prepareAlertData = (
     );
     transformedItem["satelliteUsedForDetection"] =
       satelliteLookup[item.sat_detect_prefix] || item.sat_detect_prefix;
-
     transformedItem["t0_url"] =
       `${table}/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T0_${item.alert_id}.jpg`;
     transformedItem["t1_url"] =
       `${table}/${item.territory_id}/${item.year_detec}/${formattedMonth}/${item.alert_id}/images/${item.sat_viz_prefix}_T1_${item.alert_id}.jpg`;
     transformedItem["previewImagerySource"] =
       satelliteLookup[item.sat_viz_prefix] || item.sat_viz_prefix;
-
     return transformedItem;
   };
 
   let latestProprietaryDate = new Date(0);
   let latestProprietaryMonthStr = "";
-
   const validGeoData = data.filter(isValidGeolocation);
   const proprietaryAlertData = validGeoData.filter(
     (d) => d.data_source !== "Global Forest Watch",
@@ -328,7 +238,6 @@ const prepareAlertData = (
     (d) => d.data_source === "Global Forest Watch",
   );
 
-  // First pass to find the latest date
   proprietaryAlertData.forEach((item) => {
     const formattedMonth =
       item.month_detec.length === 1 ? `0${item.month_detec}` : item.month_detec;
@@ -337,7 +246,6 @@ const prepareAlertData = (
       parseInt(item.year_detec),
       parseInt(formattedMonth) - 1,
     );
-
     if (date > latestProprietaryDate) {
       latestProprietaryDate = date;
       latestProprietaryMonthStr = monthYearStr;
@@ -353,14 +261,11 @@ const prepareAlertData = (
   const mostRecentAlerts: DataEntry[] = [];
   const previousAlerts: DataEntry[] = [];
 
-  // Second pass to segregate the data
   proprietaryAlertData.forEach((item) => {
     const formattedMonth =
       item.month_detec.length === 1 ? `0${item.month_detec}` : item.month_detec;
     const monthYearStr = `${formattedMonth}-${item.year_detec}`;
     const transformedItem = transformChangeDetectionItem(item, formattedMonth);
-
-    // Segregate data based on the latest month detected
     if (monthYearStr === latestProprietaryMonthStr) {
       mostRecentAlerts.push(transformedItem);
     } else {
@@ -381,30 +286,10 @@ const prepareAlertData = (
   return { mostRecentAlerts, previousAlerts };
 };
 
-/**
- * Prepares statistical data for the alerts view introduction panel.
- *
- * This function processes alert data and optional metadata to generate
- * statistics for display. It calculates the range of alert detection dates,
- * identifies unique alert types and data providers, and computes cumulative
- * alert counts and areas over the last 12 months.
- *
- * The statistics include:
- * - Territory name with proper capitalization.
- * - Unique types of alerts and data providers.
- * - Date range for alert detection.
- * - Cumulative alerts and hectares per month for the last 12 months.
- * - Total number of alerts and total area affected in hectares.
- *
- * @param {DataEntry[]} data - An array of data entries representing alerts.
- * @param {AlertsMetadata[] | null} metadata - Optional metadata for additional context.
- * @returns {AlertsStatistics} An object containing various statistics for the alerts view.
- */
 const prepareAlertsStatistics = (
   data: DataEntry[],
   metadata: AlertsMetadata[] | null,
 ): AlertsStatistics => {
-  // Extract data providers from metadata (reusable for empty data case)
   const getDataProvidersFromMetadata = (): string[] => {
     return metadata && metadata.length > 0
       ? Array.from(
@@ -413,7 +298,6 @@ const prepareAlertsStatistics = (
       : [];
   };
 
-  // Extract date range from metadata (reusable for empty data case)
   const getDateRangeFromMetadata = (): {
     earliestDateStr: string;
     latestDateStr: string;
@@ -421,13 +305,11 @@ const prepareAlertsStatistics = (
     latestDate: Date;
   } | null => {
     if (!metadata || metadata.length === 0) return null;
-
     metadata.sort((a, b) =>
       a.year === b.year ? a.month - b.month : a.year - b.year,
     );
     const earliestMetadata = metadata[0];
     const latestMetadata = metadata[metadata.length - 1];
-
     return {
       earliestDate: new Date(
         earliestMetadata.year,
@@ -440,20 +322,16 @@ const prepareAlertsStatistics = (
     };
   };
 
-  // Handle empty data case - but still use metadata if available
   if (data.length === 0) {
     const now = new Date();
     const currentDateStr = `${String(now.getMonth() + 1).padStart(2, "0")}-${now.getFullYear()}`;
-
     const dataProviders = getDataProvidersFromMetadata();
     const metadataDateRange = getDateRangeFromMetadata();
-
     const alertDetectionRange = metadataDateRange
       ? `${metadataDateRange.earliestDateStr} to ${metadataDateRange.latestDateStr}`
       : "N/A";
     const earliestDateStr =
       metadataDateRange?.earliestDateStr ?? currentDateStr;
-
     return {
       territory: "",
       typeOfAlerts: [],
@@ -472,7 +350,6 @@ const prepareAlertsStatistics = (
   }
 
   const isGFW = data.some((item) => item.data_source === "Global Forest Watch");
-
   const territory = isGFW
     ? ""
     : data[0].territory_name.charAt(0).toUpperCase() +
@@ -490,22 +367,16 @@ const prepareAlertsStatistics = (
     ? Array.from(new Set(data.map((item) => item.data_source).filter(Boolean)))
     : getDataProvidersFromMetadata();
 
-  // Create Date objects for sorting and comparisons
-  const formattedDates = data.map((item) => {
-    return {
-      date: new Date(
-        `${item.year_detec}-${item.month_detec.padStart(2, "0")}-15`,
-      ),
-      dateString: `${item.month_detec.padStart(2, "0")}-${item.year_detec}`,
-    };
-  });
-
-  // Sort dates to find the earliest and latest
+  const formattedDates = data.map((item) => ({
+    date: new Date(
+      `${item.year_detec}-${item.month_detec.padStart(2, "0")}-15`,
+    ),
+    dateString: `${item.month_detec.padStart(2, "0")}-${item.year_detec}`,
+  }));
   formattedDates.sort((a, b) => a.date.getTime() - b.date.getTime());
 
-  let earliestDateStr, latestDateStr;
+  let earliestDateStr: string, latestDateStr: string;
   let earliestDate: Date, latestDate: Date;
-
   const metadataDateRange = getDateRangeFromMetadata();
   if (metadataDateRange) {
     earliestDate = metadataDateRange.earliestDate;
@@ -513,26 +384,20 @@ const prepareAlertsStatistics = (
     earliestDateStr = metadataDateRange.earliestDateStr;
     latestDateStr = metadataDateRange.latestDateStr;
   } else {
-    // If metadata is null, calculate earliest and latest dates from data
     earliestDate = formattedDates[0].date;
     earliestDate.setDate(1);
     earliestDateStr = formattedDates[0].dateString;
-
     latestDate = formattedDates[formattedDates.length - 1].date;
     latestDate.setDate(28);
     latestDateStr = formattedDates[formattedDates.length - 1].dateString;
   }
 
-  // Create an array of all dates
   const allDates = Array.from(
     new Set(formattedDates.map((item) => item.dateString)),
   );
-
-  // Determine the date 12 months before the latest date
   const twelveMonthsBefore = new Date(latestDate);
   twelveMonthsBefore.setFullYear(twelveMonthsBefore.getFullYear() - 1);
 
-  // Filter and sort the data for the last 12 months
   const last12MonthsData = data
     .filter((item) => {
       const itemDate = new Date(
@@ -556,40 +421,22 @@ const prepareAlertsStatistics = (
 
   const getUpTo12MonthsForChart = (): string[] => {
     const months = [];
-
-    // We have to use UTC here to avoid issues with local time settings
     const currentDate = new Date(
       Date.UTC(latestDate.getUTCFullYear(), latestDate.getUTCMonth(), 15),
     );
-
     for (let i = 0; i < 12; i++) {
-      // Decrement the month in currentDate, after the first iteration (latestDate).
-      // This moves the date back by one month at a time.
-      if (i > 0) {
-        currentDate.setMonth(currentDate.getMonth() - 1);
-      }
-
-      // Format the month part of the currentDate to ensure it has two digits.
-      // This is necessary as months are 0-indexed in JavaScript,
-      // so January is 0, February is 1, and so on.
+      if (i > 0) currentDate.setMonth(currentDate.getMonth() - 1);
       const month = String(currentDate.getUTCMonth() + 1).padStart(2, "0");
       const year = currentDate.getUTCFullYear();
       const monthYear = `${month}-${year}`;
-
-      // Check if this currentDate falls within the range of earliestDate and latestDate.
-      // If it does, add the monthYear string to the months array.
       if (currentDate >= earliestDate && currentDate <= latestDate) {
         months.push(monthYear);
       }
     }
-
-    // Reverse the months array to have the dates in ascending order.
     months.reverse();
     return months;
   };
 
-  // Helper function to update months cumulatively
-  // Whether it be alerts or hectares
   const updateCumulativeData = (
     dataCollection: DataEntry[],
     accumulatorMap: Record<string, number>,
@@ -597,7 +444,6 @@ const prepareAlertsStatistics = (
   ) => {
     let cumulativeValue = 0;
     const months = Object.keys(accumulatorMap);
-
     months.forEach((monthYear) => {
       if (property === "alerts") {
         const monthData = dataCollection.filter((item) => {
@@ -618,21 +464,16 @@ const prepareAlertsStatistics = (
     });
   };
 
-  // Initialize alertsPerMonth and hectaresPerMonth
   const alertsPerMonth: AlertsPerMonth = {};
   const hectaresPerMonth: AlertsPerMonth = {};
   const months = getUpTo12MonthsForChart();
-
   months.forEach((monthYear) => {
     alertsPerMonth[monthYear] = 0;
     hectaresPerMonth[monthYear] = 0;
   });
-
-  // Populate alertsPerMonth and hectaresPerMonth using the helper function
   updateCumulativeData(last12MonthsData, alertsPerMonth, "alerts");
   updateCumulativeData(last12MonthsData, hectaresPerMonth, "hectares");
 
-  // Count the number of alerts for the most recent date
   const recentAlertDate =
     last12MonthsData.length > 0
       ? `${last12MonthsData[last12MonthsData.length - 1].month_detec.padStart(2, "0")}-${last12MonthsData[last12MonthsData.length - 1].year_detec}`
@@ -642,10 +483,7 @@ const prepareAlertsStatistics = (
     return itemDateStr === recentAlertDate;
   }).length;
 
-  // Calculate total number of alerts
   const alertsTotal = data.length;
-
-  // Calculate total hectares
   const hectaresTotal = isGFW
     ? null
     : data
@@ -672,34 +510,23 @@ const prepareAlertsStatistics = (
   };
 };
 
-/**
- * Transforms data entries into a GeoJSON FeatureCollection.
- *
- * @param {DataEntry[]} data - An array of data entries to be transformed.
- * @returns {FeatureCollection} A GeoJSON FeatureCollection object.
- */
 const transformToGeojson = (data: DataEntry[]): FeatureCollection => {
   const features = data.map((input) => {
     const feature: Feature = {
       type: "Feature",
       id: undefined,
-      properties: {}, // Ensure properties is always an object
+      properties: {},
       geometry: {
         type: input.g__type as "Point" | "LineString" | "Polygon",
         coordinates: [],
       },
     };
-
     Object.entries(input).forEach(([key, value]) => {
       if (key === "alertID") {
-        // Mapbox requires `feature.id` to be a 32-bit integer or a small string.
-        // Some `alertID` values (e.g. "20240910100161660491") are too large to safely cast to Number,
-        // which causes "given varint doesn't fit into 10 bytes" errors when rendering vector tiles.
-        // We hash the `alertID` with MurmurHash to ensure a safe, deterministic 32-bit integer ID.
         feature.id = murmurhash.v3(String(value));
-        feature.properties![key] = value; // Use non-null assertion
+        feature.properties![key] = value;
       } else if (key.startsWith("g__")) {
-        const geometryKey = key.substring(3); // Removes 'g__' prefix
+        const geometryKey = key.substring(3);
         if (feature.geometry) {
           if (geometryKey === "coordinates") {
             feature.geometry[geometryKey as keyof Geometry] = JSON.parse(
@@ -713,20 +540,14 @@ const transformToGeojson = (data: DataEntry[]): FeatureCollection => {
           }
         }
       } else {
-        feature.properties![key] = value; // Use non-null assertion
+        feature.properties![key] = value;
       }
     });
-
     return feature;
   });
-
-  return {
-    type: "FeatureCollection",
-    features: features,
-  };
+  return { type: "FeatureCollection", features };
 };
 
-/** Validates if a data entry has valid geolocation data. */
 const isValidGeolocation = (item: DataEntry): boolean => {
   const validGeoTypes = [
     "LineString",
@@ -735,7 +556,6 @@ const isValidGeolocation = (item: DataEntry): boolean => {
     "Polygon",
     "MultiPolygon",
   ];
-
   const isValidCoordinates = (
     type: string,
     coordinates: Geometry | string,
@@ -743,19 +563,18 @@ const isValidGeolocation = (item: DataEntry): boolean => {
     if (typeof coordinates === "string") {
       try {
         coordinates = JSON.parse(coordinates);
-      } catch (error) {
-        console.error("Error parsing coordinates:", error);
+      } catch {
         return false;
       }
     }
-
     if (type === "Point") {
       return (
         Array.isArray(coordinates) &&
         coordinates.length === 2 &&
         coordinates.every(Number.isFinite)
       );
-    } else if (type === "LineString" || type === "MultiLineString") {
+    }
+    if (type === "LineString" || type === "MultiLineString") {
       return (
         Array.isArray(coordinates) &&
         coordinates.every(
@@ -765,7 +584,8 @@ const isValidGeolocation = (item: DataEntry): boolean => {
             coord.every(Number.isFinite),
         )
       );
-    } else if (type === "Polygon") {
+    }
+    if (type === "Polygon") {
       return (
         Array.isArray(coordinates) &&
         coordinates.every(
@@ -779,7 +599,8 @@ const isValidGeolocation = (item: DataEntry): boolean => {
             ),
         )
       );
-    } else if (type === "MultiPolygon") {
+    }
+    if (type === "MultiPolygon") {
       return (
         Array.isArray(coordinates) &&
         coordinates.every(
@@ -800,31 +621,14 @@ const isValidGeolocation = (item: DataEntry): boolean => {
     }
     return false;
   };
-
   return (
     validGeoTypes.includes(item.g__type) &&
     isValidCoordinates(item.g__type, item.g__coordinates)
   );
 };
 
-/**
- * Prepares statistical data for the map view introduction panel.
- *
- * This function processes map data to generate statistics for display.
- * It calculates the total number of features, counts geometry types,
- * and determines date ranges if the data contains valid dates.
- *
- * @param {DataEntry[]} data - An array of data entries representing map features.
- * @returns {MapStatistics} An object containing various statistics for the map view.
- */
 const prepareMapStatistics = (data: DataEntry[]): MapStatistics => {
-  if (!data || data.length === 0) {
-    return {
-      totalFeatures: 0,
-    };
-  }
-
-  // Calculate date range (look for date-related columns)
+  if (!data || data.length === 0) return { totalFeatures: 0 };
   let dateRange: string | undefined;
   const dateColumns = Object.keys(data[0] || {}).filter((key) => {
     const lowerKey = key.toLowerCase();
@@ -836,15 +640,12 @@ const prepareMapStatistics = (data: DataEntry[]): MapStatistics => {
       lowerKey.includes("updated")
     );
   });
-
   if (dateColumns.length > 0) {
     const dates = data
       .map((item) => {
         for (const col of dateColumns) {
           if (item[col]) {
             const value = String(item[col]);
-            // Check if the value looks like a date (contains digits and common date separators)
-            // Pattern matches dates like: 2024-01-15, 01/15/2024, 3/9/2024, 2024, etc.
             if (
               /\d/.test(value) &&
               (/[-/]/.test(value) || /^\d{4}$/.test(value))
@@ -857,16 +658,11 @@ const prepareMapStatistics = (data: DataEntry[]): MapStatistics => {
       })
       .filter(Boolean)
       .sort();
-
     if (dates.length > 0) {
       dateRange = `${dates[0]} to ${dates[dates.length - 1]}`;
     }
   }
-
-  return {
-    totalFeatures: data.length,
-    dateRange,
-  };
+  return { totalFeatures: data.length, dateRange };
 };
 
 export {


### PR DESCRIPTION
## Goal

Move filtering and presentation transformations to the client so the API serves raw data and presentation is decoupled (subissue #269). Enables raw exports and keeps backend focused on canonical data. Closes #269 


## Screenshots

N/A


## What I changed and why

Moved `server/dataProcessing/` (helpers, filterData, transformData) to `utils/dataProcessing/` so the client can import it. Map, gallery, and alerts APIs now return raw data plus config (columns, filter settings, etc.); they no longer run transform or filter. The map, gallery, and alerts pages apply filtering and transformations client-side using the shared utils. Tests were updated to import from `@/utils/dataProcessing` and the old server module was removed. This keeps APIs as raw-data endpoints and puts display logic on the client.


## What I'm not doing here

Not adding the single-record endpoint or the minimal map endpoint; those are separate PRs. Not changing export/download behavior.


## LLM use disclosure