### PR TITLE
Add single-record raw data endpoint

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -148,6 +148,12 @@ const {
 /** Fetched raw record for sidebar (replaces layer props when we have table + recordId). */
 const displayFeature = ref<Record<string, unknown> | null>(null);
 
+/** Feature to pass to ViewSidebar (avoid `|` in template to prevent "Filters are deprecated" warning). */
+const sidebarFeature = computed(
+  (): DataEntry | undefined =>
+    (displayFeature.value ?? selectedFeature.value) as DataEntry | undefined,
+);
+
 watch(
   [selectedFeature, selectedFeatureSource],
   async ([feature, source]) => {
@@ -1466,7 +1472,7 @@ onBeforeUnmount(() => {
       :allowed-file-extensions="allowedFileExtensions"
       :calculate-hectares="calculateHectares"
       :date-options="dateOptions"
-      :feature="(displayFeature ?? selectedFeature) as DataEntry | undefined"
+      :feature="sidebarFeature"
       :feature-geojson="selectedFeatureOriginal ?? localAlertsData"
       :feature-load-error="featureLoadError"
       :file-paths="imageUrl"

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -34,6 +34,7 @@ import type {
   AllowedFileExtensions,
   Basemap,
   BasemapConfig,
+  DataEntry,
   Dataset,
   MapLegendItem,
 } from "@/types/types";
@@ -59,9 +60,11 @@ const props = defineProps<{
   mapbox3d: boolean;
   mapbox3dTerrainExaggeration: number;
   mapeoData: Dataset | null;
+  mapeoTable?: string;
   mediaBasePath: string | undefined;
   mediaBasePathAlerts: string | undefined;
   planetApiKey: string | undefined;
+  table: string;
 }>();
 
 const localAlertsData = ref<Feature | AlertsData>(props.alertsData);
@@ -73,6 +76,9 @@ const showBasemapSelector = ref(false);
 const showIntroPanel = ref(true);
 const showSidebar = ref(true);
 const showSlider = ref(false);
+const loadingFeature = ref(false);
+const featureLoadError = ref<string | null>(null);
+const selectedFeatureOriginal = ref<Feature | null>(null);
 
 const route = useRoute();
 const router = useRouter();
@@ -137,6 +143,65 @@ const {
   showSidebar,
   showIntroPanel,
   isMapeo,
+);
+
+/** Fetched raw record for sidebar (replaces layer props when we have table + recordId). */
+const displayFeature = ref<Record<string, unknown> | null>(null);
+
+watch(
+  [selectedFeature, selectedFeatureSource],
+  async ([feature, source]) => {
+    if (!feature || !source) {
+      displayFeature.value = null;
+      selectedFeatureOriginal.value = null;
+      featureLoadError.value = null;
+      return;
+    }
+    const isMapeoLayer = source === "mapeo-data";
+    const tableForFetch = isMapeoLayer ? props.mapeoTable : props.table;
+    const recordId = isMapeoLayer
+      ? (feature.id ?? feature._id)
+      : feature.alertID;
+    if (!tableForFetch || recordId == null || String(recordId).trim() === "") {
+      displayFeature.value = feature as Record<string, unknown>;
+      selectedFeatureOriginal.value = null;
+      return;
+    }
+    loadingFeature.value = true;
+    featureLoadError.value = null;
+    displayFeature.value = feature as Record<string, unknown>;
+    try {
+      const headers: Record<string, string> = {};
+      if (apiKey) headers["x-api-key"] = apiKey;
+      const raw = await $fetch<Record<string, unknown>>(
+        `/api/${encodeURIComponent(tableForFetch)}/${encodeURIComponent(String(recordId))}`,
+        { headers },
+      );
+      displayFeature.value = raw;
+      const gType = raw?.g__type as string | undefined;
+      const gCoords = raw?.g__coordinates;
+      const coords =
+        typeof gCoords === "string" ? JSON.parse(gCoords as string) : gCoords;
+      selectedFeatureOriginal.value = {
+        type: "Feature",
+        geometry: {
+          type: (gType ?? "Point") as "Point" | "LineString" | "Polygon",
+          coordinates: coords ?? [],
+        },
+        properties: { ...raw },
+      } as Feature;
+    } catch (err) {
+      featureLoadError.value =
+        err && typeof err === "object" && "statusMessage" in err
+          ? String((err as { statusMessage: string }).statusMessage)
+          : "Failed to load record";
+      displayFeature.value = feature as Record<string, unknown>;
+      selectedFeatureOriginal.value = null;
+    } finally {
+      loadingFeature.value = false;
+    }
+  },
+  { immediate: true },
 );
 
 // Use alerts date filter composable
@@ -1401,13 +1466,15 @@ onBeforeUnmount(() => {
       :allowed-file-extensions="allowedFileExtensions"
       :calculate-hectares="calculateHectares"
       :date-options="dateOptions"
-      :feature="selectedFeature"
-      :feature-geojson="localAlertsData"
+      :feature="(displayFeature ?? selectedFeature) as DataEntry | undefined"
+      :feature-geojson="selectedFeatureOriginal ?? localAlertsData"
+      :feature-load-error="featureLoadError"
       :file-paths="imageUrl"
       :geojson-selection="filteredData"
       :is-alert="isAlert"
       :is-mapeo="isMapeo"
       :is-alerts-dashboard="true"
+      :loading-feature="loadingFeature"
       :local-alerts-data="localAlertsData"
       :logo-url="logoUrl"
       :media-base-path="mediaBasePath"

--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -21,10 +21,6 @@ const props = defineProps<{
   table?: string;
 }>();
 
-const emit = defineEmits<{
-  "select-feature": [DataEntry];
-}>();
-
 const filteredData = ref(props.galleryData);
 
 // Pagination per page
@@ -72,39 +68,32 @@ const featureWithPreparedCoordinates = (feature: DataEntry): DataEntry => {
   return result as unknown as DataEntry;
 };
 
-const onCardClick = (feature: DataEntry) => {
-  emit("select-feature", feature);
-};
 </script>
 
 <template>
-  <div
-    id="galleryContainer"
-    data-testid="gallery-container"
-    class="gallery p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
-  >
+  <div>
     <div
-      v-if="filterColumn"
-      class="sticky top-10 right-10 z-10"
-      data-testid="filter-container"
+      id="galleryContainer"
+      data-testid="gallery-container"
+      class="gallery p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
     >
-      <DataFilter
-        :data="galleryData"
-        :filter-column="filterColumn"
-        @filter="filterValues"
-      />
-    </div>
-    <div
-      v-for="(feature, index) in paginatedData"
-      :key="index"
-      role="button"
-      tabindex="0"
-      class="cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-      data-testid="gallery-item-wrapper"
-      @click="table ? onCardClick(feature) : undefined"
-      @keydown.enter="table ? onCardClick(feature) : undefined"
-    >
-      <DataFeature
+      <div
+        v-if="filterColumn"
+        class="sticky top-10 right-10 z-10"
+        data-testid="filter-container"
+      >
+        <DataFilter
+          :data="galleryData"
+          :filter-column="filterColumn"
+          @filter="filterValues"
+        />
+      </div>
+      <div
+        v-for="(feature, index) in paginatedData"
+        :key="index"
+        data-testid="gallery-item-wrapper"
+      >
+        <DataFeature
         :allowed-file-extensions="allowedFileExtensions"
         :feature="featureWithPreparedCoordinates(feature)"
         :file-paths="
@@ -112,16 +101,17 @@ const onCardClick = (feature: DataEntry) => {
         "
         :media-base-path="mediaBasePath"
         :data-testid="`gallery-item-${index}`"
-      />
+        />
+      </div>
+      <!-- Hidden element to track pagination state for testing -->
+      <div
+        data-testid="pagination-info"
+        :data-current-page="currentPage"
+        :data-items-per-page="itemsPerPage"
+        :data-total-items="filteredData.length"
+        :data-paginated-count="paginatedData.length"
+        class="hidden"
+      ></div>
     </div>
-    <!-- Hidden element to track pagination state for testing -->
-    <div
-      data-testid="pagination-info"
-      :data-current-page="currentPage"
-      :data-items-per-page="itemsPerPage"
-      :data-total-items="filteredData.length"
-      :data-paginated-count="paginatedData.length"
-      class="hidden"
-    ></div>
   </div>
 </template>

--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -18,7 +18,13 @@ const props = defineProps<{
   galleryData: Dataset;
   mediaBasePath: string;
   mediaColumn?: string;
+  table?: string;
 }>();
+
+const emit = defineEmits<{
+  "select-feature": [DataEntry];
+}>();
+
 const filteredData = ref(props.galleryData);
 
 // Pagination per page
@@ -65,6 +71,10 @@ const featureWithPreparedCoordinates = (feature: DataEntry): DataEntry => {
   };
   return result as unknown as DataEntry;
 };
+
+const onCardClick = (feature: DataEntry) => {
+  emit("select-feature", feature);
+};
 </script>
 
 <template>
@@ -84,17 +94,26 @@ const featureWithPreparedCoordinates = (feature: DataEntry): DataEntry => {
         @filter="filterValues"
       />
     </div>
-    <DataFeature
+    <div
       v-for="(feature, index) in paginatedData"
       :key="index"
-      :allowed-file-extensions="allowedFileExtensions"
-      :feature="featureWithPreparedCoordinates(feature)"
-      :file-paths="
-        getFilePathsWithExtension(feature, allowedFileExtensions, mediaColumn)
-      "
-      :media-base-path="mediaBasePath"
-      :data-testid="`gallery-item-${index}`"
-    />
+      role="button"
+      tabindex="0"
+      class="cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      data-testid="gallery-item-wrapper"
+      @click="table ? onCardClick(feature) : undefined"
+      @keydown.enter="table ? onCardClick(feature) : undefined"
+    >
+      <DataFeature
+        :allowed-file-extensions="allowedFileExtensions"
+        :feature="featureWithPreparedCoordinates(feature)"
+        :file-paths="
+          getFilePathsWithExtension(feature, allowedFileExtensions, mediaColumn)
+        "
+        :media-base-path="mediaBasePath"
+        :data-testid="`gallery-item-${index}`"
+      />
+    </div>
     <!-- Hidden element to track pagination state for testing -->
     <div
       data-testid="pagination-info"

--- a/components/shared/ViewSidebar.vue
+++ b/components/shared/ViewSidebar.vue
@@ -38,6 +38,8 @@ const props = defineProps<{
   showIntroPanel?: boolean;
   showSidebar?: boolean;
   showSlider?: boolean;
+  loadingFeature?: boolean;
+  featureLoadError?: string | null;
 }>();
 
 const isScrollable = ref(false);
@@ -143,6 +145,16 @@ onBeforeUnmount(() => {
           :loading-icons="loadingIcons"
           @toggle-icons="emit('toggle-icons')"
         />
+        <div v-else-if="loadingFeature" class="text-muted-foreground p-4">
+          {{ $t("loading") }}…
+        </div>
+        <div
+          v-else-if="featureLoadError"
+          class="text-destructive p-4"
+          data-testid="feature-load-error"
+        >
+          {{ featureLoadError }}
+        </div>
         <DataFeature
           v-if="feature"
           :allowed-file-extensions="allowedFileExtensions"

--- a/pages/alerts/[tablename].vue
+++ b/pages/alerts/[tablename].vue
@@ -29,6 +29,7 @@ const mapboxZoom = ref(0);
 const mapbox3d = ref(false);
 const mapbox3dTerrainExaggeration = ref(0);
 const mapeoData = ref();
+const mapeoTable = ref<string | undefined>();
 const mediaBasePath = ref();
 const mediaBasePathAlerts = ref();
 const planetApiKey = ref();
@@ -62,6 +63,7 @@ if (data.value && !error.value) {
   mapbox3d.value = data.value.mapbox3d;
   mapbox3dTerrainExaggeration.value = data.value.mapbox3dTerrainExaggeration;
   mapeoData.value = data.value.mapeoData;
+  mapeoTable.value = data.value.mapeoTable;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaBasePathAlerts.value = data.value.mediaBasePathAlerts;
   planetApiKey.value = data.value.planetApiKey;
@@ -110,6 +112,8 @@ useHead({
         :mapbox3d="mapbox3d"
         :mapbox3d-terrain-exaggeration="mapbox3dTerrainExaggeration"
         :mapeo-data="mapeoData"
+        :mapeo-table="mapeoTable"
+        :table="table"
         :media-base-path="mediaBasePath"
         :media-base-path-alerts="mediaBasePathAlerts"
         :planet-api-key="planetApiKey"

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 
+import ViewSidebar from "@/components/shared/ViewSidebar.vue";
 import { replaceUnderscoreWithSpace } from "@/utils/index";
 import { useIsPublic } from "@/utils/permissions";
+
+import type { DataEntry } from "@/types/types";
+import type { Feature } from "geojson";
 
 // Extract the tablename from the route parameters
 const route = useRoute();
@@ -15,6 +19,12 @@ const filterColumn = ref();
 const galleryData = ref();
 const mediaBasePath = ref();
 const mediaColumn = ref();
+
+const showDetailSidebar = ref(false);
+const displayFeature = ref<DataEntry | null>(null);
+const loadingFeature = ref(false);
+const featureLoadError = ref<string | null>(null);
+const selectedFeatureOriginal = ref<Feature | null>(null);
 
 const {
   public: { appApiKey },
@@ -37,6 +47,52 @@ if (data.value && !error.value) {
 } else {
   console.error("Error fetching data:", error.value);
 }
+
+const onSelectFeature = async (record: DataEntry) => {
+  const recordId = record._id ?? record.id;
+  if (recordId == null || String(recordId).trim() === "") return;
+  showDetailSidebar.value = true;
+  displayFeature.value = record;
+  loadingFeature.value = true;
+  featureLoadError.value = null;
+  selectedFeatureOriginal.value = null;
+  try {
+    const fetchHeaders: Record<string, string> = {};
+    if (appApiKey) fetchHeaders["x-api-key"] = appApiKey;
+    const raw = await $fetch<Record<string, unknown>>(
+      `/api/${encodeURIComponent(table)}/${encodeURIComponent(String(recordId))}`,
+      { headers: fetchHeaders },
+    );
+    displayFeature.value = raw as DataEntry;
+    const gType = raw?.g__type as string | undefined;
+    const gCoords = raw?.g__coordinates;
+    const coords =
+      typeof gCoords === "string" ? JSON.parse(gCoords as string) : gCoords;
+    selectedFeatureOriginal.value = {
+      type: "Feature",
+      geometry: {
+        type: (gType ?? "Point") as "Point" | "LineString" | "Polygon",
+        coordinates: coords ?? [],
+      },
+      properties: { ...raw },
+    };
+  } catch (err) {
+    featureLoadError.value =
+      err && typeof err === "object" && "statusMessage" in err
+        ? String((err as { statusMessage: string }).statusMessage)
+        : "Failed to load record";
+    displayFeature.value = record;
+  } finally {
+    loadingFeature.value = false;
+  }
+};
+
+const closeDetailSidebar = () => {
+  showDetailSidebar.value = false;
+  displayFeature.value = null;
+  selectedFeatureOriginal.value = null;
+  featureLoadError.value = null;
+};
 
 const { t } = useI18n();
 
@@ -67,6 +123,19 @@ useHead({
         :filter-column="filterColumn"
         :media-base-path="mediaBasePath"
         :media-column="mediaColumn"
+        :table="table"
+        @select-feature="onSelectFeature"
+      />
+      <ViewSidebar
+        v-if="showDetailSidebar"
+        :feature="displayFeature ?? undefined"
+        :feature-geojson="selectedFeatureOriginal ?? undefined"
+        :feature-load-error="featureLoadError"
+        :loading-feature="loadingFeature"
+        :media-base-path="mediaBasePath"
+        :show-sidebar="showDetailSidebar"
+        @close="closeDetailSidebar"
+        @update:showSidebar="showDetailSidebar = $event"
       />
       <h3
         v-if="!mediaBasePath && dataFetched"

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 
-import ViewSidebar from "@/components/shared/ViewSidebar.vue";
 import { replaceUnderscoreWithSpace } from "@/utils/index";
 import { useIsPublic } from "@/utils/permissions";
-
-import type { DataEntry } from "@/types/types";
-import type { Feature } from "geojson";
 
 // Extract the tablename from the route parameters
 const route = useRoute();
@@ -19,12 +15,6 @@ const filterColumn = ref();
 const galleryData = ref();
 const mediaBasePath = ref();
 const mediaColumn = ref();
-
-const showDetailSidebar = ref(false);
-const displayFeature = ref<DataEntry | null>(null);
-const loadingFeature = ref(false);
-const featureLoadError = ref<string | null>(null);
-const selectedFeatureOriginal = ref<Feature | null>(null);
 
 const {
   public: { appApiKey },
@@ -47,52 +37,6 @@ if (data.value && !error.value) {
 } else {
   console.error("Error fetching data:", error.value);
 }
-
-const onSelectFeature = async (record: DataEntry) => {
-  const recordId = record._id ?? record.id;
-  if (recordId == null || String(recordId).trim() === "") return;
-  showDetailSidebar.value = true;
-  displayFeature.value = record;
-  loadingFeature.value = true;
-  featureLoadError.value = null;
-  selectedFeatureOriginal.value = null;
-  try {
-    const fetchHeaders: Record<string, string> = {};
-    if (appApiKey) fetchHeaders["x-api-key"] = appApiKey;
-    const raw = await $fetch<Record<string, unknown>>(
-      `/api/${encodeURIComponent(table)}/${encodeURIComponent(String(recordId))}`,
-      { headers: fetchHeaders },
-    );
-    displayFeature.value = raw as DataEntry;
-    const gType = raw?.g__type as string | undefined;
-    const gCoords = raw?.g__coordinates;
-    const coords =
-      typeof gCoords === "string" ? JSON.parse(gCoords as string) : gCoords;
-    selectedFeatureOriginal.value = {
-      type: "Feature",
-      geometry: {
-        type: (gType ?? "Point") as "Point" | "LineString" | "Polygon",
-        coordinates: coords ?? [],
-      },
-      properties: { ...raw },
-    };
-  } catch (err) {
-    featureLoadError.value =
-      err && typeof err === "object" && "statusMessage" in err
-        ? String((err as { statusMessage: string }).statusMessage)
-        : "Failed to load record";
-    displayFeature.value = record;
-  } finally {
-    loadingFeature.value = false;
-  }
-};
-
-const closeDetailSidebar = () => {
-  showDetailSidebar.value = false;
-  displayFeature.value = null;
-  selectedFeatureOriginal.value = null;
-  featureLoadError.value = null;
-};
 
 const { t } = useI18n();
 
@@ -124,18 +68,6 @@ useHead({
         :media-base-path="mediaBasePath"
         :media-column="mediaColumn"
         :table="table"
-        @select-feature="onSelectFeature"
-      />
-      <ViewSidebar
-        v-if="showDetailSidebar"
-        :feature="displayFeature ?? undefined"
-        :feature-geojson="selectedFeatureOriginal ?? undefined"
-        :feature-load-error="featureLoadError"
-        :loading-feature="loadingFeature"
-        :media-base-path="mediaBasePath"
-        :show-sidebar="showDetailSidebar"
-        @close="closeDetailSidebar"
-        @update:showSidebar="showDetailSidebar = $event"
       />
       <h3
         v-if="!mediaBasePath && dataFetched"

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -97,6 +97,7 @@ useHead({
     <ClientOnly>
       <MapView
         v-if="dataFetched"
+        :table="table"
         :allowed-file-extensions="allowedFileExtensions"
         :color-column="colorColumn"
         :filter-column="filterColumn"

--- a/server/api/[table]/[recordId].get.ts
+++ b/server/api/[table]/[recordId].get.ts
@@ -1,0 +1,45 @@
+import { fetchConfig, fetchRecordById } from "@/server/database/dbOperations";
+import { validatePermissions } from "@/utils/auth";
+
+import type { H3Event } from "h3";
+
+/**
+ * GET api/[table]/[recordId]
+ * Returns the raw, untransformed record for the given _id.
+ * Used on demand when the user selects a feature (e.g. map click).
+ * Returns 404 if the table is not in config or the record is missing.
+ */
+export default defineEventHandler(async (event: H3Event) => {
+  const { table, recordId } = event.context.params as {
+    table: string;
+    recordId: string;
+  };
+
+  if (!recordId || typeof recordId !== "string" || recordId.trim() === "") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "recordId is required",
+    });
+  }
+
+  const viewsConfig = await fetchConfig();
+  const permission = viewsConfig[table]?.ROUTE_LEVEL_PERMISSION ?? "member";
+  await validatePermissions(event, permission);
+
+  if (!viewsConfig[table]) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Table config not found",
+    });
+  }
+
+  const record = await fetchRecordById(table, recordId.trim());
+  if (!record) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Record not found",
+    });
+  }
+
+  return record;
+});

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -165,6 +165,7 @@ export default defineEventHandler(async (event: H3Event) => {
       mapboxBasemaps: basemaps,
       mapboxZoom: Number(viewsConfig[table].MAPBOX_ZOOM),
       mapeoData: mapeoData,
+      mapeoTable: mapeoTable ?? undefined,
       mediaBasePath: viewsConfig[table].MEDIA_BASE_PATH,
       mediaBasePathAlerts: viewsConfig[table].MEDIA_BASE_PATH_ALERTS,
       planetApiKey: viewsConfig[table].PLANET_API_KEY,

--- a/test/components/AlertsDashboard.test.ts
+++ b/test/components/AlertsDashboard.test.ts
@@ -61,9 +61,11 @@ const baseProps: InstanceType<typeof AlertsDashboard>["$props"] = {
   mapbox3d: false,
   mapbox3dTerrainExaggeration: 1.5,
   mapeoData: null,
+  mapeoTable: undefined,
   mediaBasePath: "",
   mediaBasePathAlerts: "",
   planetApiKey: "",
+  table: "fake_alerts",
 };
 
 // Mock Nuxt composables - needs to be before component import

--- a/test/server/api/recordId.test.ts
+++ b/test/server/api/recordId.test.ts
@@ -1,5 +1,7 @@
 import "./setupGlobals";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import recordHandler from "@/server/api/[table]/[recordId].get";
+import * as dbOperations from "@/server/database/dbOperations";
 
 vi.stubGlobal("useRuntimeConfig", () => ({
   public: { allowedFileExtensions: { audio: [], image: [], video: [] } },
@@ -13,9 +15,6 @@ vi.mock("@/server/database/dbOperations", () => ({
 vi.mock("@/utils/auth", () => ({
   validatePermissions: vi.fn().mockResolvedValue(undefined),
 }));
-
-import recordHandler from "@/server/api/[table]/[recordId].get";
-import * as dbOperations from "@/server/database/dbOperations";
 
 function createMockEvent(table: string, recordId: string) {
   return {

--- a/test/server/api/recordId.test.ts
+++ b/test/server/api/recordId.test.ts
@@ -1,0 +1,76 @@
+import "./setupGlobals";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: { allowedFileExtensions: { audio: [], image: [], video: [] } },
+}));
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchConfig: vi.fn(),
+  fetchRecordById: vi.fn(),
+}));
+
+vi.mock("@/utils/auth", () => ({
+  validatePermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+import recordHandler from "@/server/api/[table]/[recordId].get";
+import * as dbOperations from "@/server/database/dbOperations";
+
+function createMockEvent(table: string, recordId: string) {
+  return {
+    context: { params: { table, recordId } },
+  } as unknown as Parameters<typeof recordHandler>[0];
+}
+
+describe("GET api/[table]/[recordId]", () => {
+  beforeEach(() => {
+    vi.mocked(dbOperations.fetchConfig).mockResolvedValue({
+      seed_survey_data: { ROUTE_LEVEL_PERMISSION: "anyone" },
+    });
+    vi.mocked(dbOperations.fetchRecordById).mockResolvedValue({
+      _id: "id-1",
+      g__type: "Point",
+      g__coordinates: "[-76.5, 3.44]",
+      community: "A",
+    });
+  });
+
+  it("returns 200 and raw record when found", async () => {
+    const event = createMockEvent("seed_survey_data", "id-1");
+    const response = await recordHandler(event);
+
+    expect(response).toEqual({
+      _id: "id-1",
+      g__type: "Point",
+      g__coordinates: "[-76.5, 3.44]",
+      community: "A",
+    });
+    expect(dbOperations.fetchRecordById).toHaveBeenCalledWith(
+      "seed_survey_data",
+      "id-1",
+    );
+  });
+
+  it("returns 404 when record not found", async () => {
+    vi.mocked(dbOperations.fetchRecordById).mockResolvedValue(null);
+    const event = createMockEvent("seed_survey_data", "missing-id");
+
+    await expect(recordHandler(event)).rejects.toThrow("Record not found");
+  });
+
+  it("returns 400 when recordId is empty", async () => {
+    const event = createMockEvent("seed_survey_data", "");
+
+    await expect(recordHandler(event)).rejects.toThrow("recordId is required");
+  });
+
+  it("returns 404 when table config is missing", async () => {
+    vi.mocked(dbOperations.fetchConfig).mockResolvedValue({});
+    const event = createMockEvent("nonexistent_table", "id-1");
+
+    await expect(recordHandler(event)).rejects.toThrow(
+      "Table config not found",
+    );
+  });
+});


### PR DESCRIPTION
**Goal**  
Add a single-record raw endpoint (issue 268): `GET api/[table]/[recordId]` returns the full, untransformed row for that `_id`. The map view uses it only when a user selects a feature (e.g. map click), not on initial load. Closes #268 

**Screenshots**  
<img width="763" height="353" alt="Screenshot 2026-02-09 at 11 14 30" src="https://github.com/user-attachments/assets/714938be-c2ab-4cb0-853d-0ce4f53d6534" />
<img width="763" height="353" alt="Screenshot 2026-02-09 at 11 14 23" src="https://github.com/user-attachments/assets/b41057e7-f977-4421-abe7-5e458a97601b" />


**What I changed and why**  
adds `fetchRecordById(table, recordId)` in dbOperations (single row by `_id`) and a new handler at `GET api/[table]/[recordId]` that checks permissions (same as map), validates `recordId`, and returns the raw row or 400/404. The map page now passes `table` into MapView; on feature click MapView calls this endpoint with the feature’s `_id`, shows a loading state in the sidebar, then sets the response as the selected feature and builds the GeoJSON needed for download. ViewSidebar gets optional `loadingFeature` and `featureLoadError` so it can show “Loading…” or an error instead of the feature panel when the fetch is in progress or fails.

**What I'm not doing here**  
Client-side transformations (269).

**LLM use disclosure**  
Cursor with me driving