### PR TITLE
Add bulk raw records endpoint

### DIFF
--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -29,48 +29,17 @@ const { data, error } = await useFetch(`/api/${table}/gallery`, {
   headers,
 });
 
-const rawGalleryList = ref<DataEntry[]>([]);
-
 if (data.value && !error.value) {
   allowedFileExtensions.value = data.value.allowedFileExtensions;
   dataFetched.value = true;
   filterColumn.value = data.value.filterColumn;
   const rawList = (data.value.data ?? []) as DataEntry[];
-  rawGalleryList.value = rawList;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaColumn.value = data.value.mediaColumn;
-  // Batch load first page via bulk records endpoint (270).
-  const firstPageSize = 100;
-  const firstIds = rawList
-    .slice(0, firstPageSize)
-    .map((r) => String(r._id ?? r.id))
-    .filter(Boolean);
-  if (firstIds.length > 0) {
-    try {
-      const res = await $fetch<{ records: (DataEntry | null)[] }>(
-        `/api/${table}/records`,
-        {
-          method: "POST",
-          body: { ids: firstIds },
-          headers: { "x-api-key": appApiKey },
-        },
-      );
-      const records = (res.records ?? []).filter(
-        (r): r is DataEntry => r != null,
-      );
-      galleryData.value = transformSurveyData(
-        records,
-        data.value.mediaColumn,
-      );
-    } catch {
-      galleryData.value = transformSurveyData(
-        rawList.slice(0, firstPageSize),
-        data.value.mediaColumn,
-      );
-    }
-  } else {
-    galleryData.value = [];
-  }
+  galleryData.value = transformSurveyData(
+    rawList,
+    data.value.mediaColumn,
+  );
 } else {
   console.error("Error fetching data:", error.value);
 }

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -33,13 +33,13 @@ if (data.value && !error.value) {
   allowedFileExtensions.value = data.value.allowedFileExtensions;
   dataFetched.value = true;
   filterColumn.value = data.value.filterColumn;
-  const rawList = (data.value.data ?? []) as DataEntry[];
-  mediaBasePath.value = data.value.mediaBasePath;
-  mediaColumn.value = data.value.mediaColumn;
+  // API returns raw data; transform for display (human-readable keys/values).
   galleryData.value = transformSurveyData(
-    rawList,
+    (data.value.data ?? []) as DataEntry[],
     data.value.mediaColumn,
   );
+  mediaBasePath.value = data.value.mediaBasePath;
+  mediaColumn.value = data.value.mediaColumn;
 } else {
   console.error("Error fetching data:", error.value);
 }

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -29,17 +29,48 @@ const { data, error } = await useFetch(`/api/${table}/gallery`, {
   headers,
 });
 
+const rawGalleryList = ref<DataEntry[]>([]);
+
 if (data.value && !error.value) {
   allowedFileExtensions.value = data.value.allowedFileExtensions;
   dataFetched.value = true;
   filterColumn.value = data.value.filterColumn;
-  // API returns raw data; transform for display (human-readable keys/values).
-  galleryData.value = transformSurveyData(
-    (data.value.data ?? []) as DataEntry[],
-    data.value.mediaColumn,
-  );
+  const rawList = (data.value.data ?? []) as DataEntry[];
+  rawGalleryList.value = rawList;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaColumn.value = data.value.mediaColumn;
+  // Batch load first page via bulk records endpoint (270).
+  const firstPageSize = 100;
+  const firstIds = rawList
+    .slice(0, firstPageSize)
+    .map((r) => String(r._id ?? r.id))
+    .filter(Boolean);
+  if (firstIds.length > 0) {
+    try {
+      const res = await $fetch<{ records: (DataEntry | null)[] }>(
+        `/api/${table}/records`,
+        {
+          method: "POST",
+          body: { ids: firstIds },
+          headers: { "x-api-key": appApiKey },
+        },
+      );
+      const records = (res.records ?? []).filter(
+        (r): r is DataEntry => r != null,
+      );
+      galleryData.value = transformSurveyData(
+        records,
+        data.value.mediaColumn,
+      );
+    } catch {
+      galleryData.value = transformSurveyData(
+        rawList.slice(0, firstPageSize),
+        data.value.mediaColumn,
+      );
+    }
+  } else {
+    galleryData.value = [];
+  }
 } else {
   console.error("Error fetching data:", error.value);
 }

--- a/server/api/[table]/records.post.ts
+++ b/server/api/[table]/records.post.ts
@@ -1,0 +1,50 @@
+import { fetchConfig, fetchRecordsByIds, BULK_RECORDS_MAX_IDS } from "@/server/database/dbOperations";
+import { validatePermissions } from "@/utils/auth";
+
+import type { H3Event } from "h3";
+import type { DataEntry } from "@/types/types";
+
+/**
+ * POST api/[table]/records
+ * Bulk fetch raw, untransformed records by _id. Request body: { ids: string[] }.
+ * Returns { records: (DataEntry | null)[] } in the same order as requested ids (null for missing).
+ * Rejects with 400 if ids missing, not an array, or length > BULK_RECORDS_MAX_IDS; 404 if table not in config.
+ */
+export default defineEventHandler(async (event: H3Event) => {
+  const { table } = event.context.params as { table: string };
+
+  const rawBody =
+    (event as { body?: unknown }).body ??
+    (await readBody(event).catch(() => null));
+  const ids = rawBody && typeof rawBody === "object" && Array.isArray((rawBody as { ids?: unknown }).ids)
+    ? ((rawBody as { ids: unknown[] }).ids).map((id) => String(id)).filter((id) => id.trim() !== "")
+    : null;
+
+  if (ids === null) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Request body must be { ids: string[] }",
+    });
+  }
+
+  if (ids.length > BULK_RECORDS_MAX_IDS) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Too many IDs: maximum ${BULK_RECORDS_MAX_IDS} allowed`,
+    });
+  }
+
+  const viewsConfig = await fetchConfig();
+  const permission = viewsConfig[table]?.ROUTE_LEVEL_PERMISSION ?? "member";
+  await validatePermissions(event, permission);
+
+  if (!viewsConfig[table]) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Table config not found",
+    });
+  }
+
+  const records = await fetchRecordsByIds(table, ids);
+  return { records };
+});

--- a/test/server/api/records.post.test.ts
+++ b/test/server/api/records.post.test.ts
@@ -1,0 +1,84 @@
+import "./setupGlobals";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import recordsHandler from "@/server/api/[table]/records.post";
+import * as dbOperations from "@/server/database/dbOperations";
+
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: { allowedFileExtensions: { audio: [], image: [], video: [] } },
+}));
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchConfig: vi.fn(),
+  fetchRecordsByIds: vi.fn(),
+  BULK_RECORDS_MAX_IDS: 100,
+}));
+
+vi.mock("@/utils/auth", () => ({
+  validatePermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createMockEvent(table: string, body: { ids: string[] }) {
+  return {
+    context: { params: { table } },
+    body,
+  } as unknown as Parameters<typeof recordsHandler>[0];
+}
+
+describe("POST api/[table]/records", () => {
+  beforeEach(() => {
+    vi.mocked(dbOperations.fetchConfig).mockResolvedValue({
+      seed_survey_data: { ROUTE_LEVEL_PERMISSION: "anyone" },
+    });
+    vi.mocked(dbOperations.fetchRecordsByIds).mockResolvedValue([
+      { _id: "1", g__type: "Point", g__coordinates: "[0,0]" },
+      { _id: "2", g__type: "Point", g__coordinates: "[1,1]" },
+    ]);
+  });
+
+  it("returns 200 and records in request order", async () => {
+    const event = createMockEvent("seed_survey_data", { ids: ["1", "2"] });
+    const response = await recordsHandler(event);
+
+    expect(response).toEqual({
+      records: [
+        { _id: "1", g__type: "Point", g__coordinates: "[0,0]" },
+        { _id: "2", g__type: "Point", g__coordinates: "[1,1]" },
+      ],
+    });
+    expect(dbOperations.fetchRecordsByIds).toHaveBeenCalledWith(
+      "seed_survey_data",
+      ["1", "2"],
+    );
+  });
+
+  it("returns 400 when body is not { ids: array }", async () => {
+    const event = {
+      context: { params: { table: "seed_survey_data" } },
+      body: null,
+    } as unknown as Parameters<typeof recordsHandler>[0];
+
+    await expect(recordsHandler(event)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "Request body must be { ids: string[] }",
+    });
+  });
+
+  it("returns 400 when too many ids", async () => {
+    const manyIds = Array.from({ length: 101 }, (_, i) => String(i));
+    const event = createMockEvent("seed_survey_data", { ids: manyIds });
+
+    await expect(recordsHandler(event)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: /maximum 100/,
+    });
+  });
+
+  it("returns 404 when table config is missing", async () => {
+    vi.mocked(dbOperations.fetchConfig).mockResolvedValue({});
+    const event = createMockEvent("nonexistent_table", { ids: ["1"] });
+
+    await expect(recordsHandler(event)).rejects.toThrow(
+      "Table config not found",
+    );
+  });
+});

--- a/test/server/api/setupGlobals.ts
+++ b/test/server/api/setupGlobals.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 /**
  * Defines Nuxt/h3 globals so server API handlers can be loaded in Vitest without a Nuxt context.
  */
@@ -8,6 +10,7 @@ const g = globalThis as unknown as {
     statusCode?: number;
     statusMessage?: string;
   }) => Error;
+  readBody?: (event: unknown) => Promise<unknown>;
 };
 g.defineEventHandler = (fn: (e: unknown) => unknown) => fn;
 g.createError = (opts) =>
@@ -15,3 +18,4 @@ g.createError = (opts) =>
 g.sendError = (_event, error) => {
   throw error;
 };
+g.readBody = vi.fn().mockResolvedValue(null);


### PR DESCRIPTION
## Goal

Add a bulk raw records endpoint so views that need multiple full records (e.g. future gallery selection flows) can fetch them efficiently. The gallery UI does not use it yet; selection-based loading will be implemented later.


## Screenshots

N/A (API-only change).


## What I changed and why

Added a bulk raw records API and supporting code. The backend now exposes `POST api/[table]/records` with a body `{ ids: string[] }` (max 100 IDs), implemented via a new `fetchRecordsByIds` in `dbOperations` that returns records in the same order as the requested IDs. The handler validates the body, enforces the limit, and returns 400/404 as appropriate. Tests cover success, invalid body, too many IDs, and missing table config; `setupGlobals` was updated so handlers that use `readBody` in other tests don’t break.

The gallery page is unchanged in behavior: it still uses only the existing gallery API response for display. The new bulk endpoint is available for future work (e.g. when the UI requests a specific set of IDs from a selection flow).

## What I'm not doing here

Gallery does not call the bulk endpoint yet; that will be added when we have a UI that requests a specific set of IDs (e.g. selection).