### PR TITLE
Implement Client Side Record Caching

### DIFF
--- a/composables/useRecordFetch.ts
+++ b/composables/useRecordFetch.ts
@@ -1,0 +1,143 @@
+/**
+ * Client-side record cache and request de-duplication for dataset views.
+ * Cache is keyed by table + _id. In-flight requests for the same key
+ * share one network call.
+ *
+ * Invalidation: Currently we invalidate only when explicitly called
+ * (invalidate(table?, id?) or clear()). A future strategy could tie
+ * invalidation to table switch, TTL, or data mutations — see TODO in invalidate().
+ */
+import type { DataEntry } from "@/types/types";
+
+export type RawRecord = Record<string, unknown>;
+
+const cache = new Map<string, RawRecord>();
+const inFlight = new Map<string, Promise<RawRecord | null>>();
+
+/** @param {string} table - Table name. @param {string} id - Record id. @returns {string} Cache key. */
+const cacheKey = (table: string, id: string): string => `${table}:${id}`;
+
+/** @returns {Record<string, string>} Headers including x-api-key when configured. */
+const getHeaders = (): Record<string, string> => {
+  const config = useRuntimeConfig();
+  const key = config.public?.appApiKey as string | undefined;
+  const headers: Record<string, string> = {};
+  if (key) headers["x-api-key"] = key;
+  return headers;
+};
+
+/**
+ * Fetch a single raw record by table and id. Uses cache and de-duplicates
+ * in-flight requests for the same table+id.
+ * @param {string} table - Table name.
+ * @param {string} id - Record _id.
+ * @returns {Promise<RawRecord | null>} Raw record or null if not found.
+ */
+export const getRecord = (
+  table: string,
+  id: string,
+): Promise<RawRecord | null> => {
+  const key = cacheKey(table, id);
+  const cached = cache.get(key);
+  if (cached !== undefined) return Promise.resolve(cached);
+
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = $fetch<RawRecord | null>(
+    `/api/${encodeURIComponent(table)}/${encodeURIComponent(String(id))}`,
+    { headers: getHeaders() },
+  )
+    .then((raw) => {
+      if (raw != null) cache.set(key, raw);
+      inFlight.delete(key);
+      return raw;
+    })
+    .catch((err) => {
+      inFlight.delete(key);
+      throw err;
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+};
+
+const BULK_MAX = 100;
+
+/**
+ * Fetch multiple raw records by table and ids. Uses POST api/[table]/records,
+ * then stores each result in the cache so subsequent getRecord() calls hit cache.
+ * Returns array in same order as ids; null for missing or beyond first BULK_MAX unique.
+ * @param {string} table - Table name.
+ * @param {string[]} ids - Record ids.
+ * @returns {Promise<(RawRecord | null)[]>} Records in request order (null where missing).
+ */
+export const getRecords = (
+  table: string,
+  ids: string[],
+): Promise<(RawRecord | null)[]> => {
+  const unique = [...new Set(ids)];
+  const toFetch = unique.slice(0, BULK_MAX);
+  if (toFetch.length === 0) return Promise.resolve(ids.map(() => null));
+
+  return $fetch<{ records: (DataEntry | null)[] }>(
+    `/api/${encodeURIComponent(table)}/records`,
+    {
+      method: "POST",
+      body: { ids: toFetch },
+      headers: getHeaders(),
+    },
+  ).then((res) => {
+    const records = res.records ?? [];
+    const byId = new Map<string, RawRecord | null>();
+    records.forEach((r, i) => {
+      const id = toFetch[i];
+      const raw = r as RawRecord | null;
+      byId.set(id, raw);
+      if (raw != null) cache.set(cacheKey(table, id), raw);
+    });
+    return ids.map((id) => byId.get(id) ?? null);
+  });
+};
+
+/**
+ * Invalidate cached records so the next getRecord/getRecords refetches.
+ * - invalidate(table, id): remove one record
+ * - invalidate(table): remove all records for table
+ * - invalidate(): clear entire cache
+ * @param {string} [table] - Table name; omit to clear all.
+ * @param {string} [id] - Record id; omit to clear whole table.
+ * @returns {void}
+ * @todo Consider invalidation on table switch, TTL, or after mutations.
+ */
+export const invalidate = (table?: string, id?: string): void => {
+  if (table === undefined) {
+    cache.clear();
+    return;
+  }
+  if (id !== undefined) {
+    cache.delete(cacheKey(table, id));
+    return;
+  }
+  const prefix = `${table}:`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+};
+
+/** Clear entire cache and in-flight tracking. @returns {void} */
+export const clear = (): void => {
+  cache.clear();
+  inFlight.clear();
+};
+
+/**
+ * Composable that exposes getRecord, getRecords, invalidate, and clear.
+ * @returns {{ getRecord: typeof getRecord; getRecords: typeof getRecords; invalidate: typeof invalidate; clear: typeof clear }}
+ */
+export const useRecordFetch = () => ({
+  getRecord,
+  getRecords,
+  invalidate,
+  clear,
+});

--- a/test/composables/useRecordFetch.test.ts
+++ b/test/composables/useRecordFetch.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getRecord,
+  getRecords,
+  invalidate,
+  clear,
+  useRecordFetch,
+} from "@/composables/useRecordFetch";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("$fetch", mockFetch);
+  vi.stubGlobal("useRuntimeConfig", () => ({
+    public: { appApiKey: "test-key" },
+  }));
+  mockFetch.mockReset();
+  clear();
+});
+
+describe("useRecordFetch", () => {
+  describe("getRecord", () => {
+    it("returns cached data without issuing a network request on second call", async () => {
+      const record = { _id: "r1", name: "First" };
+      mockFetch.mockResolvedValue(record);
+
+      const first = await getRecord("t1", "r1");
+      const second = await getRecord("t1", "r1");
+
+      expect(first).toEqual(record);
+      expect(second).toEqual(record);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("de-duplicates concurrent requests for the same table and id", async () => {
+      const record = { _id: "r1", name: "First" };
+      mockFetch.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(record), 20)),
+      );
+
+      const [a, b, c] = await Promise.all([
+        getRecord("t1", "r1"),
+        getRecord("t1", "r1"),
+        getRecord("t1", "r1"),
+      ]);
+
+      expect(a).toEqual(record);
+      expect(b).toEqual(record);
+      expect(c).toEqual(record);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls GET api/[table]/[recordId] with encoded params", async () => {
+      mockFetch.mockResolvedValue({ _id: "id-1" });
+      await getRecord("my_table", "id-1");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/my_table/id-1",
+        expect.objectContaining({ headers: { "x-api-key": "test-key" } }),
+      );
+    });
+
+    it("after invalidate(table, id), next getRecord refetches", async () => {
+      const record = { _id: "r1", name: "First" };
+      mockFetch.mockResolvedValue(record);
+
+      await getRecord("t1", "r1");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      invalidate("t1", "r1");
+      await getRecord("t1", "r1");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("after invalidate(table), next getRecord for that table refetches", async () => {
+      mockFetch.mockResolvedValue({ _id: "r1" });
+      await getRecord("t1", "r1");
+      mockFetch.mockResolvedValue({ _id: "r2" });
+      await getRecord("t1", "r2");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      invalidate("t1");
+      mockFetch.mockResolvedValue({ _id: "r1" });
+      await getRecord("t1", "r1");
+      mockFetch.mockResolvedValue({ _id: "r2" });
+      await getRecord("t1", "r2");
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it("exposes getRecord via useRecordFetch()", () => {
+      const { getRecord: getRecordFromComposable } = useRecordFetch();
+      expect(getRecordFromComposable).toBe(getRecord);
+    });
+  });
+
+  describe("getRecords", () => {
+    it("calls POST api/[table]/records and returns records in request order", async () => {
+      const records = [
+        { _id: "a", name: "A" },
+        { _id: "b", name: "B" },
+      ];
+      mockFetch.mockResolvedValue({ records });
+
+      const result = await getRecords("t1", ["a", "b"]);
+
+      expect(result).toEqual(records);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/t1/records",
+        expect.objectContaining({
+          method: "POST",
+          body: { ids: ["a", "b"] },
+          headers: { "x-api-key": "test-key" },
+        }),
+      );
+    });
+
+    it("populates cache so getRecord returns without network", async () => {
+      const records = [{ _id: "r1", name: "R1" }];
+      mockFetch.mockResolvedValue({ records });
+
+      await getRecords("t1", ["r1"]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const single = await getRecord("t1", "r1");
+      expect(single).toEqual(records[0]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("clears cache so next getRecord refetches", async () => {
+      mockFetch.mockResolvedValue({ _id: "r1" });
+      await getRecord("t1", "r1");
+      clear();
+      mockFetch.mockResolvedValue({ _id: "r1" });
+      await getRecord("t1", "r1");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Add client-side caching and request de-duplication for raw record fetches so map clicks, alerts feature selection, and navigation don’t re-fetch the same record repeatedly. 


## Screenshots

N/A (behavior unchanged; fewer duplicate requests).


## What I changed and why

Added a `useRecordFetch` composable: an in-memory cache keyed by table+id and an in-flight map so concurrent requests for the same record share one network call. Exposes `getRecord(table, id)`, `getRecords(table, ids)` (uses bulk endpoint and fills cache), `invalidate(table?, id?)`, and `clear()`. MapView and AlertsDashboard now use `getRecord()` for sidebar detail fetches instead of direct `$fetch`. Invalidation is explicit only; a short TODO in code notes possible future strategies (e.g. table switch, TTL). 

## What I'm not doing here

Gallery does not use the cache or bulk endpoint yet. Cache invalidation strategy is left as TODO (no TTL or automatic invalidation).


## LLM use disclosure
None.