### PR TITLE
Fix negative number input in map config lat/long fields

### DIFF
--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -38,7 +38,16 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
   emit("updateConfig", { [key]: values });
 };
 
+/**
+ * Handles input changes and emits the updated config value.
+ * Guards against incomplete numeric input (e.g. "-", "-.") to prevent
+ * NaN from being emitted, which would clear the field and block negative entry.
+ *
+ * @param {string} key - The config key being updated.
+ * @param {string | number | boolean} value - The new value from the input.
+ */
 const handleInput = (key: string, value: string | number | boolean): void => {
+  if (typeof value === "number" && isNaN(value)) return;
   emit("updateConfig", { [key]: value });
 };
 
@@ -375,8 +384,12 @@ const handleDrop = (e: DragEvent, dropIndex: number) => {
           "
           :value="configData[key]"
           @input="
-            (e) =>
-              handleInput(key, parseFloat((e.target as HTMLInputElement).value))
+            (e) => {
+              const raw = (e.target as HTMLInputElement).value;
+              if (raw === '' || raw === '-' || raw === '.' || raw === '-.')
+                return;
+              handleInput(key, parseFloat(raw));
+            }
           "
           @wheel="(e) => e.target && (e.target as HTMLInputElement).blur()"
         />


### PR DESCRIPTION
## Goal

Fix the issue where pressing the "-" key as the first character in the latitude, longitude, or bearing number inputs on the map config screen is silently ignored, making it difficult to enter negative coordinates. Closes #319 

## Screenshots


## What I changed and why

In `ConfigMap.vue`, when a user tabs into a number field and types "-", the browser's `input` event fires with a raw value of `"-"`. The existing handler called `parseFloat("-")` which returns `NaN`, and that `NaN` was emitted to the parent — effectively resetting the field and swallowing the minus sign. I added a guard in the template-level `@input` handler to skip emission when the raw value is an incomplete numeric fragment (`"-"`, `"."`, `"-."`), and a secondary guard in `handleInput` to reject `NaN` values. This lets the browser's native `<input type="number">` hold onto the partial input until the user finishes typing a valid number.

## What I'm not doing here

Not changing any validation ranges, step behavior, or other number input UX beyond the negative-sign fix.

## LLM use disclosure
