### PR TITLE
Fix white-on-white "No description" text on dataset page with header image

### DIFF
--- a/pages/dataset/[tablename].vue
+++ b/pages/dataset/[tablename].vue
@@ -241,26 +241,26 @@ useHead({
           </div>
         </div>
 
-        <div class="relative p-6 sm:p-8 text-white">
+        <div class="relative p-6 sm:p-8">
           <div class="mb-6 sm:mb-8">
             <div v-if="description || isDescriptionTruncated">
-              <p class="text-base sm:text-lg text-black leading-relaxed">
+              <p class="text-base sm:text-lg text-gray-700 leading-relaxed">
                 {{ description }}
               </p>
               <button
                 v-if="isDescriptionTruncated"
-                class="text-purple-300 hover:text-purple-100 text-sm font-medium underline mt-2"
+                class="text-purple-600 hover:text-purple-800 text-sm font-medium underline mt-2"
                 @click="isDescriptionExpanded = !isDescriptionExpanded"
               >
                 {{ isDescriptionExpanded ? "Show less" : "Show more" }}
               </button>
             </div>
-            <div v-else class="text-base sm:text-lg text-white/70 italic">
+            <div v-else class="text-base sm:text-lg text-gray-500 italic">
               <span>{{ $t("noDescriptionProvidedYet") }}</span>
               <NuxtLink
                 v-if="isAdmin"
                 :to="`/config/${tableName}`"
-                class="ml-1 text-purple-300 hover:text-purple-100 underline"
+                class="ml-1 text-purple-600 hover:text-purple-800 underline"
               >
                 {{ $t("addDescription") }}
               </NuxtLink>
@@ -285,7 +285,7 @@ useHead({
           </div>
 
           <div v-else class="text-center py-8">
-            <p class="text-white/70 text-sm sm:text-base">
+            <p class="text-gray-500 text-sm sm:text-base">
               {{
                 $t("noDatasetViewsAvailable") ||
                 "No views available for this dataset"


### PR DESCRIPTION
## Goal

Make the "No description provided yet." text and associated links readable on the dataset page when a header image is configured. Closes #323 

## Screenshots
<img width="1295" height="530" alt="Screenshot 2026-02-17 at 14 12 56" src="https://github.com/user-attachments/assets/a0c7f111-7338-4633-8538-7649ddb4b4d1" />


## What I changed and why
On `/dataset/[tablename]`, a `text-white` class on the container was causing child text to be invisible against the white background. I removed it and updated all text to readable dark tones (`text-gray-700`, `text-gray-500`, `text-purple-600`), aligning with the non-image fallback styling.



## What I'm not doing here


## LLM use disclosure
Cursor Agent (Opus 4.6) handled it pretty quick tbh 
