### PR TITLE
hide incidents UI on mobile viewports

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -1533,46 +1533,49 @@ onBeforeUnmount(() => {
       :planet-api-key="planetApiKey"
       @basemap-selected="handleBasemapChange"
     />
-    <IncidentsSidebar
-      :incidents="incidents"
-      :incidents-total="incidentsTotal"
-      :is-loading-more="isLoadingMoreIncidents"
-      :selected-incident="selectedIncident"
-      :selected-incident-data="selectedIncidentData"
-      :selected-incident-entries="selectedIncidentEntries"
-      :is-loading-selected-incident="isLoadingSelectedIncident"
-      :selected-sources="selectedSources"
-      :is-loading="isLoadingIncidents"
-      :is-creating="isCreatingIncident"
-      :show="showIncidentsSidebar"
-      :open-with-create-form="openSidebarWithCreateForm"
-      @close="toggleIncidentsSidebar"
-      @back-to-incidents-list="clearSelectedIncident"
-      @select-incident="openIncidentDetails"
-      @hover-incident="scheduleIncidentPrefetch"
-      @load-more-incidents="loadMoreIncidents"
-      @create-incident="createIncident"
-      @remove-source="removeSourceFromSelection"
-      @clear-sources="handleClearSourcesAndCloseSidebar"
-    />
-    <IncidentsControls
-      :show-incidents-sidebar="showIncidentsSidebar"
-      :open-sidebar-with-create-form="openSidebarWithCreateForm"
-      :bounding-box-mode="boundingBoxMode"
-      :multi-select-mode="multiSelectMode"
-      :has-active-selection="hasActiveSelection"
-      :selected-sources-length="selectedSources.length"
-      :hovered-button="hoveredButton"
-      @toggle-incidents-sidebar="toggleIncidentsSidebar"
-      @toggle-bounding-box-mode="toggleBoundingBoxMode"
-      @toggle-multi-select-mode="toggleMultiSelectMode"
-      @open-incidents-sidebar-with-create-form="
-        openIncidentsSidebarWithCreateForm
-      "
-      @clear-selection="handleExplicitDeselect"
-      @hover-button="(button) => (hoveredButton = button)"
-      @clear-hover="hoveredButton = null"
-    />
+    <!-- Incidents UI is hidden on mobile — too clunky for small screens -->
+    <div class="hidden md:block">
+      <IncidentsSidebar
+        :incidents="incidents"
+        :incidents-total="incidentsTotal"
+        :is-loading-more="isLoadingMoreIncidents"
+        :selected-incident="selectedIncident"
+        :selected-incident-data="selectedIncidentData"
+        :selected-incident-entries="selectedIncidentEntries"
+        :is-loading-selected-incident="isLoadingSelectedIncident"
+        :selected-sources="selectedSources"
+        :is-loading="isLoadingIncidents"
+        :is-creating="isCreatingIncident"
+        :show="showIncidentsSidebar"
+        :open-with-create-form="openSidebarWithCreateForm"
+        @close="toggleIncidentsSidebar"
+        @back-to-incidents-list="clearSelectedIncident"
+        @select-incident="openIncidentDetails"
+        @hover-incident="scheduleIncidentPrefetch"
+        @load-more-incidents="loadMoreIncidents"
+        @create-incident="createIncident"
+        @remove-source="removeSourceFromSelection"
+        @clear-sources="handleClearSourcesAndCloseSidebar"
+      />
+      <IncidentsControls
+        :show-incidents-sidebar="showIncidentsSidebar"
+        :open-sidebar-with-create-form="openSidebarWithCreateForm"
+        :bounding-box-mode="boundingBoxMode"
+        :multi-select-mode="multiSelectMode"
+        :has-active-selection="hasActiveSelection"
+        :selected-sources-length="selectedSources.length"
+        :hovered-button="hoveredButton"
+        @toggle-incidents-sidebar="toggleIncidentsSidebar"
+        @toggle-bounding-box-mode="toggleBoundingBoxMode"
+        @toggle-multi-select-mode="toggleMultiSelectMode"
+        @open-incidents-sidebar-with-create-form="
+          openIncidentsSidebarWithCreateForm
+        "
+        @clear-selection="handleExplicitDeselect"
+        @hover-button="(button) => (hoveredButton = button)"
+        @clear-hover="hoveredButton = null"
+      />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION

## Goal

Remove the incidents sidebar and control buttons from mobile viewports where the UI is too complex for touch interaction. Closes #331 

## Screenshots
<img width="496" height="529" alt="Screenshot 2026-02-17 at 14 31 17" src="https://github.com/user-attachments/assets/1da033e4-6683-4d5d-a9cc-17b18e1e3f18" />


## What I changed and why

The incidents feature includes a sidebar with incident management, plus five control buttons (view incidents, bounding box  I wrapped both `IncidentsSidebar` and `IncidentsControls` in a `hidden md:block` container so they are only rendered on screens 768px and above. 

## What I'm not doing here

Not creating a simplified mobile incidents UI. Not changing any incidents logic or desktop behavior.

## LLM use disclosure

Opus 4.6 did a  pretty simple change