### PR TITLE
Fix Map Legend z-index on mobile to be less than sidebar

### DIFF
--- a/components/shared/MapLegend.vue
+++ b/components/shared/MapLegend.vue
@@ -139,7 +139,7 @@ watch(
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  z-index: 1000;
+  z-index: 10;
 }
 
 .color-box {


### PR DESCRIPTION
## Goal

Ensure the ViewSidebar renders above the Map Legend on mobile viewports. Closes #330 

## Screenshots
<img width="496" height="529" alt="Screenshot 2026-02-17 at 14 37 12" src="https://github.com/user-attachments/assets/15891286-1c46-4239-9349-4dbfc8ef2fb1" />


## What I changed and why

I lowered the legend's z-index to `10`, which keeps it above map controls but well below the sidebar's z-50.

## What I'm not doing here

N/A
## LLM use disclosure

LLM was used for consultation and code generation for this fix.