### PR TITLE
Fix overlapping toolbars on small browser height windows

### DIFF
--- a/components/alerts/IncidentsControls.vue
+++ b/components/alerts/IncidentsControls.vue
@@ -193,8 +193,7 @@ const emit = defineEmits<{
 <style scoped>
 .incidents-controls {
   position: absolute;
-  top: calc(50% - 60px);
-  transform: translateY(-50%);
+  top: 230px;
   right: 10px;
   z-index: 10;
   display: flex;


### PR DESCRIPTION
## Goal

Fix the overlapping toolbars (incidents controls and Mapbox navigation controls) that occurs on small browser window heights. Closes #335 

## Screenshots
<img width="442" height="606" alt="Screenshot 2026-02-18 at 09 29 49" src="https://github.com/user-attachments/assets/f543ca29-1ada-466a-a821-81143681993f" />
<img width="442" height="606" alt="Screenshot 2026-02-18 at 09 29 44" src="https://github.com/user-attachments/assets/88da99de-5d9d-4151-87b6-f91db0e486f9" />

## What I changed and why

The incidents controls in `IncidentsControls.vue` were positioned using `top: calc(50% - 60px)` with `transform: translateY(-50%)`, which vertically centers them on the right side of the map. On short viewport heights, this caused them to rise into and overlap the Mapbox navigation/fullscreen/ruler controls and basemap selector stacked in the top-right. Replaced with a fixed `top: 230px` and removed the `translateY(-50%)` transform, so the incidents controls always sit just below the Mapbox control stack (~217px) regardless of viewport height.

## What I'm not doing here



## LLM use disclosure

Cursor especially for consultatiion on calc