### PR TITLE
Add dataset view type icons to filter pill buttons on home page

### DIFF
--- a/e2e/03-index.spec.ts
+++ b/e2e/03-index.spec.ts
@@ -164,6 +164,40 @@ test("index page - view filter persists in URL query param", async ({
   }
 });
 
+test("index page - view type filter buttons display icons", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='dataset-card']", {
+    timeout: 15000,
+  });
+
+  const mapButton = page.getByRole("button", { name: /^map$/i });
+  const mapButtonExists = (await mapButton.count()) > 0;
+
+  if (mapButtonExists) {
+    const mapIcon = mapButton.locator("svg");
+    await expect(mapIcon).toBeVisible({ timeout: 5000 });
+  }
+
+  const alertsButton = page.getByRole("button", { name: /^alerts$/i });
+  const alertsButtonExists = (await alertsButton.count()) > 0;
+
+  if (alertsButtonExists) {
+    const alertsIcon = alertsButton.locator("svg");
+    await expect(alertsIcon).toBeVisible({ timeout: 5000 });
+  }
+
+  const galleryButton = page.getByRole("button", { name: /^gallery$/i });
+  const galleryButtonExists = (await galleryButton.count()) > 0;
+
+  if (galleryButtonExists) {
+    const galleryIcon = galleryButton.locator("svg");
+    await expect(galleryIcon).toBeVisible({ timeout: 5000 });
+  }
+});
+
 test("index page - search bar filters dataset cards by name", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -260,7 +260,7 @@ useHead({
       >
         <div class="flex flex-wrap gap-2">
           <button
-            class="px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors"
+            class="inline-flex items-center px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors"
             :class="
               activeViewFilter === 'all'
                 ? 'bg-purple-700 text-white border-purple-700'
@@ -273,7 +273,7 @@ useHead({
           <button
             v-for="viewType in availableViewTypes"
             :key="viewType"
-            class="px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors capitalize"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors capitalize"
             :class="
               activeViewFilter === viewType
                 ? 'bg-purple-700 text-white border-purple-700'
@@ -281,6 +281,45 @@ useHead({
             "
             @click="activeViewFilter = viewType"
           >
+            <svg
+              v-if="viewType === 'map'"
+              class="w-3.5 h-3.5"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <svg
+              v-else-if="viewType === 'gallery'"
+              class="w-3.5 h-3.5"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <svg
+              v-else-if="viewType === 'alerts'"
+              class="w-3.5 h-3.5"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+              />
+            </svg>
             {{ $t(viewType) }}
           </button>
         </div>


### PR DESCRIPTION
## Goal

Add dataset view icons (map, gallery, alerts) to the filter pill buttons on the home page, matching the icons already shown on the dataset card view tags. Closes #334 .

## Screenshots


## What I changed and why

 Added the same SVG icons to the filter buttons using conditional `v-if`/`v-else-if` rendering, with `inline-flex items-center gap-1.5` for proper alignment. Also added an e2e test verifying each filter button contains an SVG icon when the corresponding view type exists.

## What I'm not doing here

Not extracting the icons into a shared component — they're small inline SVGs used in only two places.

## LLM use disclosure

None