### PR TITLE
Fix: [Incidents] toast appearing behind window

### DIFF
--- a/components/shared/ToastContainer.vue
+++ b/components/shared/ToastContainer.vue
@@ -15,7 +15,7 @@ const { toasts, removeToast } = useToast();
     :duration="toast.duration || 0"
     :visible="true"
     :position="toast.position || 'top-right'"
-    :style="{ zIndex: 1000 - index }"
+    :style="{ zIndex: 10000 - index }"
     @close="removeToast(toast.id)"
   />
 </template>


### PR DESCRIPTION
## Goal

Fix the bug where the toast notification appears behind the create-incident window when an error occurs (e.g. failed to create incident). Closes #369.


## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-03-18 at 18 40 31" src="https://github.com/user-attachments/assets/35c395bc-c7c9-4704-87fa-952fcb7d392c" />



## What I changed and why

Raised the toast z-index in `ToastContainer.vue` from `1000 - index` to `10000 - index` so toasts stack above the incidents sidebar and create-incident panel (both at z-index 1000). No other behavior or UI changes.


## What I'm not doing here

Adding a way to force a 500 for testing; that was reverted after manual verification.


## LLM use disclosure
None