### PR TITLE
Bugfix: DataFilter clear-all and map reset

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -427,6 +427,7 @@ const prepareMapCanvasContent = async () => {
 
 const selectedFilterValues = ref<FilterValues>([]);
 const { dateMin, dateMax, setDateRange } = useTimestampFilter();
+const filterResetKey = ref(0);
 
 /** Apply date range then category filter (AND). */
 const applyAllFilters = () => {
@@ -505,6 +506,12 @@ const resetToInitialState = () => {
   showSidebar.value = true;
   showIntroPanel.value = true;
 
+  // Reset filters
+  selectedFilterValues.value = [];
+  setDateRange({ start: null, end: null });
+  filterResetKey.value++;
+  applyAllFilters();
+
   // Fly to the initial position
   map.value.flyTo({
     center: [props.mapboxLongitude || 0, props.mapboxLatitude || -15],
@@ -572,6 +579,7 @@ onBeforeUnmount(() => {
     <div class="absolute top-4 right-14 z-10 flex flex-col gap-0.5">
       <DataFilter
         v-if="filterColumn"
+        :key="`filter-${filterResetKey}`"
         :data="flatDataForFilter"
         :filter-column="filterColumn"
         :color-column="colorColumn"
@@ -580,6 +588,7 @@ onBeforeUnmount(() => {
       />
       <TimestampFilter
         v-if="timestampColumn"
+        :key="`timestamp-${filterResetKey}`"
         :data="flatDataForFilter"
         :timestamp-column="timestampColumn"
         @filter="onTimestampFilter"

--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -55,12 +55,7 @@ const getUniqueFilterValues = computed(() => {
 });
 
 const emitFilterSelection = () => {
-  if (selectedFilterValue.value.length > 0) {
-    const labels = selectedFilterValue.value;
-    emit("filter", labels);
-  } else {
-    emit("filter", "null");
-  }
+  emit("filter", [...selectedFilterValue.value]);
 };
 </script>
 
@@ -75,8 +70,8 @@ const emitFilterSelection = () => {
       :is-multi="true"
       :options="getUniqueFilterValues"
       data-testid="filter-select"
-      @option-selected="emitFilterSelection()"
-      @option-deselected="emitFilterSelection()"
+      @option-selected="emitFilterSelection"
+      @option-deselected="emitFilterSelection"
     >
       <!-- This is what shows in the listbox when selected -->
       <template #tag="{ option, removeOption }">

--- a/tests/unit/components/DataFilter.test.ts
+++ b/tests/unit/components/DataFilter.test.ts
@@ -221,7 +221,7 @@ describe("DataFilter component", () => {
     expect(vm.getUniqueFilterValues).toHaveLength(2);
   });
 
-  it("emits filter event when selection changes", async () => {
+  it("emits selected values on option-selected", async () => {
     const wrapper = mount(DataFilter, {
       props: baseProps,
       global: globalConfig,
@@ -229,31 +229,66 @@ describe("DataFilter component", () => {
 
     const vm = wrapper.vm as unknown as {
       selectedFilterValue: { value: string }[];
-      emitFilterSelection: () => void;
     };
 
-    vm.selectedFilterValue = [{ value: "Camp" }];
-    vm.emitFilterSelection();
+    // Simulate what vue3-select-component does: mutate array then emit event
+    vm.selectedFilterValue.push({ value: "Camp" });
+    const vueSelect = wrapper.findComponent({ name: "VueSelect" });
+    await vueSelect.vm.$emit("optionSelected", { value: "Camp" });
 
-    expect(wrapper.emitted("filter")).toBeTruthy();
-    expect(wrapper.emitted("filter")?.[0]).toEqual([[{ value: "Camp" }]]);
+    const filterEvents = wrapper.emitted("filter")!;
+    expect(filterEvents).toHaveLength(1);
+    expect(filterEvents[0]).toEqual([[{ value: "Camp" }]]);
   });
 
-  it("emits 'null' when no selection is made", async () => {
+  it("emits empty array on clear-all (not the string 'null')", async () => {
     const wrapper = mount(DataFilter, {
       props: baseProps,
       global: globalConfig,
     });
 
     const vm = wrapper.vm as unknown as {
-      selectedFilterValue: never[];
-      emitFilterSelection: () => void;
+      selectedFilterValue: { value: string }[];
     };
 
-    vm.selectedFilterValue = [];
-    vm.emitFilterSelection();
+    // Select something first
+    vm.selectedFilterValue.push({ value: "Camp" });
+    const vueSelect = wrapper.findComponent({ name: "VueSelect" });
+    await vueSelect.vm.$emit("optionSelected", { value: "Camp" });
 
-    expect(wrapper.emitted("filter")).toBeTruthy();
-    expect(wrapper.emitted("filter")?.[0]).toEqual(["null"]);
+    // Clear all: library replaces array with [] and emits optionDeselected(null)
+    vm.selectedFilterValue.splice(0);
+    await vueSelect.vm.$emit("optionDeselected", null);
+
+    const filterEvents = wrapper.emitted("filter")!;
+    expect(filterEvents).toHaveLength(2);
+    expect(filterEvents[0]).toEqual([[{ value: "Camp" }]]);
+    expect(filterEvents[1]).toEqual([[]]);
+  });
+
+  it("emits remaining values on option-deselected", async () => {
+    const wrapper = mount(DataFilter, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const vm = wrapper.vm as unknown as {
+      selectedFilterValue: { value: string }[];
+    };
+    const vueSelect = wrapper.findComponent({ name: "VueSelect" });
+
+    // Select two
+    vm.selectedFilterValue.push({ value: "Camp" }, { value: "Water Source" });
+    await vueSelect.vm.$emit("optionSelected", { value: "Camp" });
+
+    // Remove one (library uses .filter() which reassigns)
+    vm.selectedFilterValue.splice(0, vm.selectedFilterValue.length, {
+      value: "Water Source",
+    });
+    await vueSelect.vm.$emit("optionDeselected", { value: "Camp" });
+
+    const filterEvents = wrapper.emitted("filter")!;
+    expect(filterEvents).toHaveLength(2);
+    expect(filterEvents[1]).toEqual([[{ value: "Water Source" }]]);
   });
 });


### PR DESCRIPTION
## Goal

 Clearing all filter selections (via the X button) or hitting the map reset button on the Map view left the map stuck in its filtered state. 

The root cause: `vue3-select-component` fires `@option-deselected` on clear-all, which triggered `emitFilterSelection`, but that emitted the string `"null"` when the selection was empty. Downstream, `normalizeFilterValues("null")` called `.map()` on a string, crashing silently and leaving stale filters in place.


## What I changed and why

- DataFilter now emits `[]` instead of `"null"`; `filterByDateAndCategory` skips filtering on empty arrays
- MapView reset button now clears filter/date state and remounts filter components via `:key`
- Added tests covering select, deselect, and clear-all scenarios

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None
