### PR TITLE
Download button for individual record on MapView does not return all columns

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -1710,6 +1710,7 @@ onBeforeUnmount(() => {
       :allowed-file-extensions="allowedFileExtensions"
       :calculate-hectares="calculateHectares"
       :date-options="dateOptions"
+      :export-table-name="isMapeo ? mapeoTable : table"
       :feature="selectedFeature"
       :feature-loading="selectedFeatureLoading"
       :feature-geojson="localAlertsData"

--- a/components/shared/DataFeature.vue
+++ b/components/shared/DataFeature.vue
@@ -68,24 +68,6 @@ const exportRecordId = computed(() =>
     props.feature as Record<string, unknown>,
   ),
 );
-
-watch(
-  exportRecordId,
-  (recordId) => {
-    if (!import.meta.dev) {
-      return;
-    }
-    console.debug("[DataFeature] warehouse export recordId", {
-      recordId,
-      hasMapFeature:
-        !!props.featureGeojson &&
-        typeof props.featureGeojson === "object" &&
-        "type" in props.featureGeojson &&
-        props.featureGeojson.type === "Feature",
-    });
-  },
-  { immediate: true },
-);
 </script>
 
 <template>

--- a/components/shared/DataFeature.vue
+++ b/components/shared/DataFeature.vue
@@ -11,6 +11,7 @@ import type { Feature } from "geojson";
 
 const props = defineProps<{
   allowedFileExtensions?: AllowedFileExtensions;
+  exportTableName?: string;
   feature: DataEntry;
   featureGeojson?: Feature | AlertsData;
   filePaths?: Array<string>;
@@ -195,6 +196,7 @@ const exportRecordId = computed(() =>
       <DownloadMapData
         :data-for-download="featureForDownload"
         :export-record-id="exportRecordId"
+        :export-table-name="exportTableName"
         :filename-prefix="exportRecordId"
       />
     </div>

--- a/components/shared/DataFeature.vue
+++ b/components/shared/DataFeature.vue
@@ -4,6 +4,7 @@ import DownloadMapData from "@/components/shared/DownloadMapData.vue";
 import { Copy, Check } from "lucide-vue-next";
 import AlertTooltip from "@/components/alerts/AlertTooltip.vue";
 import { useCopyLink } from "@/composables/useCopyLink";
+import { warehouseRecordIdForExport } from "@/utils/identifierUtils";
 
 import type { AllowedFileExtensions, DataEntry, AlertsData } from "@/types";
 import type { Feature } from "geojson";
@@ -59,6 +60,32 @@ const featureForDownload = computed((): Feature | AlertsData | null => {
 
   return null;
 });
+
+/** Warehouse `_id` for server-side raw export (see {@link warehouseRecordIdForExport}). */
+const exportRecordId = computed(() =>
+  warehouseRecordIdForExport(
+    props.featureGeojson,
+    props.feature as Record<string, unknown>,
+  ),
+);
+
+watch(
+  exportRecordId,
+  (recordId) => {
+    if (!import.meta.dev) {
+      return;
+    }
+    console.debug("[DataFeature] warehouse export recordId", {
+      recordId,
+      hasMapFeature:
+        !!props.featureGeojson &&
+        typeof props.featureGeojson === "object" &&
+        "type" in props.featureGeojson &&
+        props.featureGeojson.type === "Feature",
+    });
+  },
+  { immediate: true },
+);
 </script>
 
 <template>
@@ -183,7 +210,11 @@ const featureForDownload = computed((): Feature | AlertsData | null => {
 
     <!-- Download section for individual feature -->
     <div v-if="featureForDownload" class="p-6 pt-0">
-      <DownloadMapData :data-for-download="featureForDownload" />
+      <DownloadMapData
+        :data-for-download="featureForDownload"
+        :export-record-id="exportRecordId"
+        :filename-prefix="exportRecordId"
+      />
     </div>
   </div>
 </template>

--- a/components/shared/DownloadMapData.vue
+++ b/components/shared/DownloadMapData.vue
@@ -11,7 +11,7 @@ import { escapeCSVValue } from "@/utils/csvUtils";
 const props = defineProps<{
   dataForDownload?: Feature | FeatureCollection | AlertsData;
   /** Warehouse `_id` for a selected map feature; triggers server export with full raw columns. */
-  exportRecordId?: string | number;
+  exportRecordId?: string;
   exportTableName?: string;
   exportFilterColumn?: string;
   exportFilterValues?: string[];
@@ -26,11 +26,6 @@ const exportingFormat = ref<string | null>(null);
 const { t } = useI18n();
 const { warning: showWarningToast } = useToast();
 const { downloadTableExport, getTablename } = useTableExportDownload();
-
-const normalizedExportRecordId = (): string | undefined => {
-  const raw = String(props.exportRecordId ?? "").trim();
-  return raw === "" ? undefined : raw;
-};
 
 /** Incoming feature data can be either a single Feature, FeatureCollection, or an AlertsData object */
 const isAlertsData = (
@@ -62,7 +57,8 @@ const isBulkDownload = computed(() => {
 
 /** Use the server export route for bulk data or a single record identified by `_id`. */
 const useServerExport = computed(() => {
-  return isBulkDownload.value || !!normalizedExportRecordId();
+  const id = props.exportRecordId?.trim();
+  return isBulkDownload.value || !!id;
 });
 
 /**
@@ -85,8 +81,8 @@ const downloadFromExportEndpoint = async (
       exportMinDate: props.exportMinDate,
       exportMaxDate: props.exportMaxDate,
       exportTimestampColumn: props.exportTimestampColumn,
-      filenamePrefix: props.filenamePrefix ?? normalizedExportRecordId(),
-      recordId: normalizedExportRecordId(),
+      filenamePrefix: props.filenamePrefix ?? props.exportRecordId?.trim(),
+      recordId: props.exportRecordId?.trim(),
     });
   } finally {
     exportingFormat.value = null;

--- a/components/shared/DownloadMapData.vue
+++ b/components/shared/DownloadMapData.vue
@@ -11,7 +11,8 @@ import { escapeCSVValue } from "@/utils/csvUtils";
 const props = defineProps<{
   dataForDownload?: Feature | FeatureCollection | AlertsData;
   /** Warehouse `_id` for a selected map feature; triggers server export with full raw columns. */
-  exportRecordId?: string;
+  exportRecordId?: string | number;
+  exportTableName?: string;
   exportFilterColumn?: string;
   exportFilterValues?: string[];
   exportMinDate?: string;
@@ -25,6 +26,11 @@ const exportingFormat = ref<string | null>(null);
 const { t } = useI18n();
 const { warning: showWarningToast } = useToast();
 const { downloadTableExport, getTablename } = useTableExportDownload();
+
+const normalizedExportRecordId = (): string | undefined => {
+  const raw = String(props.exportRecordId ?? "").trim();
+  return raw === "" ? undefined : raw;
+};
 
 /** Incoming feature data can be either a single Feature, FeatureCollection, or an AlertsData object */
 const isAlertsData = (
@@ -56,8 +62,7 @@ const isBulkDownload = computed(() => {
 
 /** Use the server export route for bulk data or a single record identified by `_id`. */
 const useServerExport = computed(() => {
-  const id = props.exportRecordId?.trim();
-  return isBulkDownload.value || !!id;
+  return isBulkDownload.value || !!normalizedExportRecordId();
 });
 
 /**
@@ -74,13 +79,14 @@ const downloadFromExportEndpoint = async (
   try {
     await downloadTableExport({
       format,
+      exportTableName: props.exportTableName,
       exportFilterColumn: props.exportFilterColumn,
       exportFilterValues: props.exportFilterValues,
       exportMinDate: props.exportMinDate,
       exportMaxDate: props.exportMaxDate,
       exportTimestampColumn: props.exportTimestampColumn,
-      filenamePrefix: props.filenamePrefix ?? props.exportRecordId?.trim(),
-      recordId: props.exportRecordId?.trim(),
+      filenamePrefix: props.filenamePrefix ?? normalizedExportRecordId(),
+      recordId: normalizedExportRecordId(),
     });
   } finally {
     exportingFormat.value = null;

--- a/components/shared/DownloadMapData.vue
+++ b/components/shared/DownloadMapData.vue
@@ -10,6 +10,8 @@ import { escapeCSVValue } from "@/utils/csvUtils";
 
 const props = defineProps<{
   dataForDownload?: Feature | FeatureCollection | AlertsData;
+  /** Warehouse `_id` for a selected map feature; triggers server export with full raw columns. */
+  exportRecordId?: string;
   exportFilterColumn?: string;
   exportFilterValues?: string[];
   exportMinDate?: string;
@@ -52,6 +54,12 @@ const isBulkDownload = computed(() => {
   );
 });
 
+/** Use the server export route for bulk data or a single record identified by `_id`. */
+const useServerExport = computed(() => {
+  const id = props.exportRecordId?.trim();
+  return isBulkDownload.value || !!id;
+});
+
 /**
  * Downloads spatial dataset files from the server export endpoint. For bulk export, the server
  * handles data formatting and streams the response; the client saves the blob to disk.
@@ -71,7 +79,8 @@ const downloadFromExportEndpoint = async (
       exportMinDate: props.exportMinDate,
       exportMaxDate: props.exportMaxDate,
       exportTimestampColumn: props.exportTimestampColumn,
-      filenamePrefix: props.filenamePrefix,
+      filenamePrefix: props.filenamePrefix ?? props.exportRecordId?.trim(),
+      recordId: props.exportRecordId?.trim(),
     });
   } finally {
     exportingFormat.value = null;
@@ -243,7 +252,7 @@ const downloadAlertKML = () => {
       :disabled="!!exportingFormat"
       type="button"
       @click="
-        isBulkDownload ? downloadFromExportEndpoint('csv') : downloadAlertCSV()
+        useServerExport ? downloadFromExportEndpoint('csv') : downloadAlertCSV()
       "
     >
       {{ exportingFormat === "csv" ? $t("downloading") : $t("downloadCSV") }}
@@ -253,7 +262,7 @@ const downloadAlertKML = () => {
       :disabled="!!exportingFormat"
       type="button"
       @click="
-        isBulkDownload
+        useServerExport
           ? downloadFromExportEndpoint('geojson')
           : downloadAlertGeoJSON()
       "
@@ -269,7 +278,7 @@ const downloadAlertKML = () => {
       :disabled="!!exportingFormat"
       type="button"
       @click="
-        isBulkDownload ? downloadFromExportEndpoint('kml') : downloadAlertKML()
+        useServerExport ? downloadFromExportEndpoint('kml') : downloadAlertKML()
       "
     >
       {{ exportingFormat === "kml" ? $t("downloading") : $t("downloadKML") }}

--- a/components/shared/ViewSidebar.vue
+++ b/components/shared/ViewSidebar.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   calculateHectares?: boolean;
   canToggleIcons?: boolean;
   dateOptions?: Array<string>;
+  exportTableName?: string;
   feature?: DataEntry;
   featureLoading?: boolean;
   featureGeojson?: Feature | AlertsData;
@@ -175,6 +176,7 @@ onBeforeUnmount(() => {
         <DataFeature
           v-if="feature && !featureLoading"
           :allowed-file-extensions="allowedFileExtensions"
+          :export-table-name="exportTableName"
           :feature="filteredFeature"
           :feature-geojson="featureGeojson"
           :file-paths="filePaths"

--- a/composables/useFeatureSelection.ts
+++ b/composables/useFeatureSelection.ts
@@ -296,8 +296,8 @@ export function useFeatureSelection(
     if (featureObject.alertID) {
       query.alertId = featureObject.alertID;
       isMapeo.value = false;
-    } else if (featureObject.id) {
-      query.mapeoDocId = featureObject.id;
+    } else if (featureObject.id || featureObject._id) {
+      query.mapeoDocId = featureObject.id || featureObject._id;
       isMapeo.value = true;
     }
     router.replace({ query });

--- a/composables/useTableExportDownload.ts
+++ b/composables/useTableExportDownload.ts
@@ -28,7 +28,7 @@ export const buildTableExportQueryParams = (options: {
   recordId?: string;
 }): Record<string, string> => {
   const params: Record<string, string> = { format: options.format };
-  const trimmedRecordId = String(options.recordId ?? "").trim();
+  const trimmedRecordId = options.recordId?.trim();
   if (trimmedRecordId) {
     params.recordId = trimmedRecordId;
   }
@@ -64,14 +64,7 @@ export function useTableExportDownload() {
    */
   const getTablename = (): string => {
     const tablename = route.params.tablename;
-    if (Array.isArray(tablename)) {
-      const joined = tablename.map(String).join("/").trim();
-      return joined === "" ? "data" : joined;
-    }
-    if (typeof tablename === "string" && tablename.trim() !== "") {
-      return tablename.trim();
-    }
-    return "data";
+    return typeof tablename === "string" ? tablename : "data";
   };
 
   /**
@@ -104,8 +97,7 @@ export function useTableExportDownload() {
     recordId?: string;
   }): Promise<void> => {
     const exportPath = options.exportPath ?? "export";
-    const tablename =
-      String(options.exportTableName ?? "").trim() || getTablename();
+    const tablename = options.exportTableName?.trim() || getTablename();
     if (tablename === "data") {
       console.error("No table name available for export.");
       showWarningToast(t("errorNoDataToDownload"));
@@ -127,11 +119,8 @@ export function useTableExportDownload() {
         params,
         responseType: "blob",
       });
-      const recordIdForName = String(options.recordId ?? "").trim();
       const filenameBase =
-        options.filenamePrefix ??
-        (recordIdForName === "" ? undefined : recordIdForName) ??
-        tablename;
+        options.filenamePrefix ?? options.recordId?.trim() ?? tablename;
       triggerBrowserDownload(blob, `${filenameBase}.${options.format}`);
     } catch (error) {
       console.error(`Failed to export ${options.format}:`, error);

--- a/composables/useTableExportDownload.ts
+++ b/composables/useTableExportDownload.ts
@@ -28,7 +28,7 @@ export const buildTableExportQueryParams = (options: {
   recordId?: string;
 }): Record<string, string> => {
   const params: Record<string, string> = { format: options.format };
-  const trimmedRecordId = options.recordId?.trim();
+  const trimmedRecordId = String(options.recordId ?? "").trim();
   if (trimmedRecordId) {
     params.recordId = trimmedRecordId;
   }
@@ -64,7 +64,14 @@ export function useTableExportDownload() {
    */
   const getTablename = (): string => {
     const tablename = route.params.tablename;
-    return typeof tablename === "string" ? tablename : "data";
+    if (Array.isArray(tablename)) {
+      const joined = tablename.map(String).join("/").trim();
+      return joined === "" ? "data" : joined;
+    }
+    if (typeof tablename === "string" && tablename.trim() !== "") {
+      return tablename.trim();
+    }
+    return "data";
   };
 
   /**
@@ -79,6 +86,7 @@ export function useTableExportDownload() {
    * @param options.exportMinDate - Optional statistics or timestamp range start.
    * @param options.exportMaxDate - Optional statistics or timestamp range end.
    * @param options.exportTimestampColumn - When set, date range applies to spatial export.
+   * @param options.exportTableName - Optional table override for shared download UIs like AlertsDashboard Mapeo.
    * @param options.filenamePrefix - Download basename without extension; defaults to the table name.
    * @param options.recordId - Optional warehouse `_id` to export a single row with full raw columns.
    * @returns {Promise<void>}
@@ -86,6 +94,7 @@ export function useTableExportDownload() {
   const downloadTableExport = async (options: {
     exportPath?: string;
     format: TableExportFormat;
+    exportTableName?: string;
     exportFilterColumn?: string;
     exportFilterValues?: string[];
     exportMinDate?: string;
@@ -95,7 +104,8 @@ export function useTableExportDownload() {
     recordId?: string;
   }): Promise<void> => {
     const exportPath = options.exportPath ?? "export";
-    const tablename = getTablename();
+    const tablename =
+      String(options.exportTableName ?? "").trim() || getTablename();
     if (tablename === "data") {
       console.error("No table name available for export.");
       showWarningToast(t("errorNoDataToDownload"));
@@ -117,8 +127,11 @@ export function useTableExportDownload() {
         params,
         responseType: "blob",
       });
+      const recordIdForName = String(options.recordId ?? "").trim();
       const filenameBase =
-        options.filenamePrefix ?? options.recordId?.trim() ?? tablename;
+        options.filenamePrefix ??
+        (recordIdForName === "" ? undefined : recordIdForName) ??
+        tablename;
       triggerBrowserDownload(blob, `${filenameBase}.${options.format}`);
     } catch (error) {
       console.error(`Failed to export ${options.format}:`, error);

--- a/composables/useTableExportDownload.ts
+++ b/composables/useTableExportDownload.ts
@@ -14,6 +14,7 @@ export type TableExportFormat = "csv" | "geojson" | "kml";
  * @param options.exportMinDate - Start of date range (when applicable).
  * @param options.exportMaxDate - End of date range (when applicable).
  * @param options.exportTimestampColumn - When set for spatial export, date range params are applied.
+ * @param options.recordId - When set, export only the row whose `_id` matches (raw warehouse id).
  * @returns {Record<string, string>} Query string parameters for the request.
  */
 export const buildTableExportQueryParams = (options: {
@@ -24,8 +25,13 @@ export const buildTableExportQueryParams = (options: {
   exportMinDate?: string;
   exportMaxDate?: string;
   exportTimestampColumn?: string;
+  recordId?: string;
 }): Record<string, string> => {
   const params: Record<string, string> = { format: options.format };
+  const trimmedRecordId = options.recordId?.trim();
+  if (trimmedRecordId) {
+    params.recordId = trimmedRecordId;
+  }
   if (options.exportFilterColumn && options.exportFilterValues?.length) {
     params.filterColumn = options.exportFilterColumn;
     params.filterValues = options.exportFilterValues.join(",");
@@ -74,6 +80,7 @@ export function useTableExportDownload() {
    * @param options.exportMaxDate - Optional statistics or timestamp range end.
    * @param options.exportTimestampColumn - When set, date range applies to spatial export.
    * @param options.filenamePrefix - Download basename without extension; defaults to the table name.
+   * @param options.recordId - Optional warehouse `_id` to export a single row with full raw columns.
    * @returns {Promise<void>}
    */
   const downloadTableExport = async (options: {
@@ -85,6 +92,7 @@ export function useTableExportDownload() {
     exportMaxDate?: string;
     exportTimestampColumn?: string;
     filenamePrefix?: string;
+    recordId?: string;
   }): Promise<void> => {
     const exportPath = options.exportPath ?? "export";
     const tablename = getTablename();
@@ -103,12 +111,14 @@ export function useTableExportDownload() {
         exportMinDate: options.exportMinDate,
         exportMaxDate: options.exportMaxDate,
         exportTimestampColumn: options.exportTimestampColumn,
+        recordId: options.recordId,
       });
       const blob = await $fetch<Blob>(`/api/${tablename}/${exportPath}`, {
         params,
         responseType: "blob",
       });
-      const filenameBase = options.filenamePrefix ?? tablename;
+      const filenameBase =
+        options.filenamePrefix ?? options.recordId?.trim() ?? tablename;
       triggerBrowserDownload(blob, `${filenameBase}.${options.format}`);
     } catch (error) {
       console.error(`Failed to export ${options.format}:`, error);

--- a/server/api/[table]/export.get.ts
+++ b/server/api/[table]/export.get.ts
@@ -12,7 +12,13 @@ import tokml from "tokml";
 
 import type { H3Event } from "h3";
 import type { DataEntry, ColumnEntry } from "@/types";
-import type { Feature, FeatureCollection, Geometry, Position } from "geojson";
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  Position,
+} from "geojson";
 
 const SUPPORTED_FORMATS = ["csv", "geojson", "kml"] as const;
 type ExportFormat = (typeof SUPPORTED_FORMATS)[number];
@@ -45,58 +51,114 @@ const buildCsv = (data: DataEntry[], columns: ColumnEntry[] | null): string => {
 
 /**
  * Builds a GeoJSON FeatureCollection from raw database rows.
- * Only includes records with valid coordinates. All non-geometry
- * fields are included as Feature properties.
+ * Rows without valid geometry are skipped unless `allowNullGeometry` is true
+ * (single-record export), in which case one Feature per row uses `geometry: null`
+ * and still carries all non-`g__` properties.
  *
  * @param {DataEntry[]} data - Raw database rows.
+ * @param {boolean} [allowNullGeometry] - When true, emit features with null geometry if coords are missing or invalid.
  * @returns {FeatureCollection} A valid GeoJSON FeatureCollection.
  */
-const buildGeoJson = (data: DataEntry[]): FeatureCollection => {
-  const features: Feature[] = [];
+const buildGeoJson = (
+  data: DataEntry[],
+  allowNullGeometry = false,
+): FeatureCollection => {
+  const features: Array<Feature<Geometry | null, GeoJsonProperties>> = [];
 
   for (const entry of data) {
-    if (!hasValidCoordinates(entry)) continue;
-
-    const geoType = entry.g__type as string | undefined;
-    const rawCoords = entry.g__coordinates as string | undefined;
-    if (!geoType || !rawCoords) continue;
-
-    let coordinates: Position | Position[] | Position[][] | Position[][][];
-    try {
-      coordinates = JSON.parse(rawCoords);
-    } catch {
-      continue;
-    }
-
-    const geometry: Geometry = {
-      type: geoType as Geometry["type"],
-      coordinates,
-    } as Geometry;
-
     const properties: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(entry)) {
       if (key.startsWith("g__")) continue;
       properties[key] = value;
     }
 
-    features.push({
-      type: "Feature",
-      geometry,
-      properties,
-    });
+    const geoType = entry.g__type as string | undefined;
+    const rawCoords = entry.g__coordinates as string | undefined;
+    let placed = false;
+
+    if (hasValidCoordinates(entry) && geoType && rawCoords) {
+      try {
+        const coordinates = JSON.parse(rawCoords) as
+          | Position
+          | Position[]
+          | Position[][]
+          | Position[][][];
+        const geometry: Geometry = {
+          type: geoType as Geometry["type"],
+          coordinates,
+        } as Geometry;
+        features.push({
+          type: "Feature",
+          geometry,
+          properties,
+        });
+        placed = true;
+      } catch {
+        // fall through to optional null-geometry feature
+      }
+    }
+
+    if (!placed && allowNullGeometry) {
+      const nullGeomFeature: Feature<Geometry | null, GeoJsonProperties> = {
+        type: "Feature",
+        geometry: null,
+        properties,
+      };
+      features.push(nullGeomFeature);
+    }
   }
 
   return {
     type: "FeatureCollection",
-    features,
+    features: features as Feature[],
   };
 };
 
 /**
+ * KML from properties only when geometry is missing (tokml skips invalid/null geometry).
+ *
+ * @param {Record<string, unknown>} properties - Feature properties (non-geometry columns).
+ * @param {string} documentName - Document title in the KML.
+ * @returns {string} A minimal KML document.
+ */
+const buildKmlPropertiesOnly = (
+  properties: Record<string, unknown>,
+  documentName: string,
+): string => {
+  const xmlEncode = (s: string) =>
+    s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+
+  const dataTags = Object.entries(properties)
+    .map(
+      ([k, v]) =>
+        `<Data name="${xmlEncode(k)}"><value>${xmlEncode(String(v ?? ""))}</value></Data>`,
+    )
+    .join("");
+
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<kml xmlns="http://www.opengis.net/kml/2.2">' +
+    "<Document>" +
+    `<name>${xmlEncode(documentName)}</name>` +
+    "<Placemark>" +
+    "<name>Exported record</name>" +
+    "<description>No valid map geometry in source; attributes only.</description>" +
+    `<ExtendedData>${dataTags}</ExtendedData>` +
+    "</Placemark>" +
+    "</Document></kml>"
+  );
+};
+
+/**
  * Streaming export endpoint for raw dataset downloads.
- * Accepts a `format` query parameter (csv, geojson, kml) and returns
- * the dataset as a file download with appropriate Content-Type and
- * Content-Disposition headers.
+ * Accepts a `format` query parameter (csv, geojson, kml) and optional
+ * `recordId` (warehouse `_id`) to export a single row with the same raw
+ * columns as the full-dataset export. Returns the dataset as a file download
+ * with appropriate Content-Type and Content-Disposition headers.
  *
  * @param {H3Event} event - The incoming HTTP event.
  * @returns {string} The formatted export content.
@@ -120,8 +182,25 @@ export default defineEventHandler(async (event: H3Event) => {
 
     const { mainData, columnsData } = await fetchData(table);
 
-    // Users expect all of their data when they download; therefore, we do not apply config-based filter-out (FILTER_BY_COLUMN / FILTER_OUT_VALUES). We only keep valid geo and, when provided, the user’s current map filter (filterColumn/filterValues) and date range (minDate/maxDate).
-    let dataToExport = filterGeoData(mainData);
+    const recordIdParam = (query.recordId as string | undefined)?.trim() ?? "";
+
+    let scopedData: DataEntry[] = mainData;
+    if (recordIdParam) {
+      scopedData = mainData.filter((row) => String(row._id) === recordIdParam);
+      if (scopedData.length === 0) {
+        throw createError({
+          statusCode: 404,
+          statusMessage: "Record not found",
+        });
+      }
+    }
+
+    const singleRecordExport = Boolean(recordIdParam);
+
+    // Users expect all of their data when they download; therefore, we do not apply config-based filter-out (FILTER_BY_COLUMN / FILTER_OUT_VALUES). Bulk export keeps only rows with valid geo. Single-record export keeps the full warehouse row so CSV / GeoJSON / KML all carry the same raw attributes (GeoJSON may use null geometry; see KML branch).
+    let dataToExport = singleRecordExport
+      ? scopedData
+      : filterGeoData(scopedData);
 
     const filterColumn = (query.filterColumn as string)?.trim();
     const filterValues = (query.filterValues as string)?.trim();
@@ -157,7 +236,7 @@ export default defineEventHandler(async (event: H3Event) => {
     }
 
     if (format === "geojson") {
-      const geojson = buildGeoJson(dataToExport);
+      const geojson = buildGeoJson(dataToExport, singleRecordExport);
       setResponseHeader(
         event,
         "Content-Type",
@@ -172,8 +251,18 @@ export default defineEventHandler(async (event: H3Event) => {
     }
 
     if (format === "kml") {
-      const geojson = buildGeoJson(dataToExport);
-      const kml = tokml(geojson);
+      const geojson = buildGeoJson(dataToExport, singleRecordExport);
+      const first = geojson.features[0];
+      const kml =
+        singleRecordExport &&
+        first?.geometry === null &&
+        first.properties &&
+        Object.keys(first.properties).length > 0
+          ? buildKmlPropertiesOnly(
+              first.properties as Record<string, unknown>,
+              table,
+            )
+          : tokml(geojson);
       setResponseHeader(
         event,
         "Content-Type",

--- a/server/api/[table]/export.get.ts
+++ b/server/api/[table]/export.get.ts
@@ -115,45 +115,6 @@ const buildGeoJson = (
 };
 
 /**
- * KML from properties only when geometry is missing (tokml skips invalid/null geometry).
- *
- * @param {Record<string, unknown>} properties - Feature properties (non-geometry columns).
- * @param {string} documentName - Document title in the KML.
- * @returns {string} A minimal KML document.
- */
-const buildKmlPropertiesOnly = (
-  properties: Record<string, unknown>,
-  documentName: string,
-): string => {
-  const xmlEncode = (s: string) =>
-    s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-
-  const dataTags = Object.entries(properties)
-    .map(
-      ([k, v]) =>
-        `<Data name="${xmlEncode(k)}"><value>${xmlEncode(String(v ?? ""))}</value></Data>`,
-    )
-    .join("");
-
-  return (
-    '<?xml version="1.0" encoding="UTF-8"?>' +
-    '<kml xmlns="http://www.opengis.net/kml/2.2">' +
-    "<Document>" +
-    `<name>${xmlEncode(documentName)}</name>` +
-    "<Placemark>" +
-    "<name>Exported record</name>" +
-    "<description>No valid map geometry in source; attributes only.</description>" +
-    `<ExtendedData>${dataTags}</ExtendedData>` +
-    "</Placemark>" +
-    "</Document></kml>"
-  );
-};
-
-/**
  * Streaming export endpoint for raw dataset downloads.
  * Accepts a `format` query parameter (csv, geojson, kml) and optional
  * `recordId` (warehouse `_id`) to export a single row with the same raw
@@ -251,18 +212,8 @@ export default defineEventHandler(async (event: H3Event) => {
     }
 
     if (format === "kml") {
-      const geojson = buildGeoJson(dataToExport, singleRecordExport);
-      const first = geojson.features[0];
-      const kml =
-        singleRecordExport &&
-        first?.geometry === null &&
-        first.properties &&
-        Object.keys(first.properties).length > 0
-          ? buildKmlPropertiesOnly(
-              first.properties as Record<string, unknown>,
-              table,
-            )
-          : tokml(geojson);
+      const geojson = buildGeoJson(dataToExport);
+      const kml = tokml(geojson);
       setResponseHeader(
         event,
         "Content-Type",

--- a/tests/unit/components/DownloadMapData.test.ts
+++ b/tests/unit/components/DownloadMapData.test.ts
@@ -229,5 +229,63 @@ describe("DownloadMapData component", () => {
         }),
       );
     });
+
+    it("uses an explicit export table name when provided", async () => {
+      const wrapper = mount(DownloadMapData, {
+        props: {
+          dataForDownload: {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-80, 43] },
+            properties: { _id: "254137982", community: "other" },
+          },
+          exportRecordId: "254137982",
+          exportTableName: "mapeo_records",
+        },
+        global: globalConfig,
+      });
+
+      const csvButton = wrapper.findAll("button")[0];
+      await csvButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/mapeo_records/export",
+        expect.objectContaining({
+          params: {
+            format: "csv",
+            recordId: "254137982",
+          },
+        }),
+      );
+    });
+
+    it("coerces numeric exportRecordId for server export requests", async () => {
+      const wrapper = mount(DownloadMapData, {
+        props: {
+          dataForDownload: {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-80, 43] },
+            properties: { _id: 254137982, community: "other" },
+          },
+          exportRecordId: 254137982,
+          exportTableName: "mapeo_records",
+        },
+        global: globalConfig,
+      });
+
+      const csvButton = wrapper.findAll("button")[0];
+      await csvButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/mapeo_records/export",
+        expect.objectContaining({
+          params: {
+            format: "csv",
+            recordId: "254137982",
+          },
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/components/DownloadMapData.test.ts
+++ b/tests/unit/components/DownloadMapData.test.ts
@@ -201,5 +201,33 @@ describe("DownloadMapData component", () => {
         }),
       );
     });
+
+    it("calls export endpoint with recordId for a selected map feature", async () => {
+      const wrapper = mount(DownloadMapData, {
+        props: {
+          dataForDownload: {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-80, 43] },
+            properties: { _id: "254137982", community: "other" },
+          },
+          exportRecordId: "254137982",
+        },
+        global: globalConfig,
+      });
+
+      const csvButton = wrapper.findAll("button")[0];
+      await csvButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/test_data/export",
+        expect.objectContaining({
+          params: {
+            format: "csv",
+            recordId: "254137982",
+          },
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/components/DownloadMapData.test.ts
+++ b/tests/unit/components/DownloadMapData.test.ts
@@ -258,34 +258,5 @@ describe("DownloadMapData component", () => {
         }),
       );
     });
-
-    it("coerces numeric exportRecordId for server export requests", async () => {
-      const wrapper = mount(DownloadMapData, {
-        props: {
-          dataForDownload: {
-            type: "Feature",
-            geometry: { type: "Point", coordinates: [-80, 43] },
-            properties: { _id: 254137982, community: "other" },
-          },
-          exportRecordId: 254137982,
-          exportTableName: "mapeo_records",
-        },
-        global: globalConfig,
-      });
-
-      const csvButton = wrapper.findAll("button")[0];
-      await csvButton.trigger("click");
-      await wrapper.vm.$nextTick();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/api/mapeo_records/export",
-        expect.objectContaining({
-          params: {
-            format: "csv",
-            recordId: "254137982",
-          },
-        }),
-      );
-    });
   });
 });

--- a/tests/unit/composables/useTableExportDownload.test.ts
+++ b/tests/unit/composables/useTableExportDownload.test.ts
@@ -47,4 +47,17 @@ describe("buildTableExportQueryParams", () => {
       maxDate: "202403",
     });
   });
+
+  it("includes recordId when provided for single-row export", () => {
+    expect(
+      buildTableExportQueryParams({
+        format: "csv",
+        exportPath: "export",
+        recordId: "  rec-abc  ",
+      }),
+    ).toEqual({
+      format: "csv",
+      recordId: "rec-abc",
+    });
+  });
 });

--- a/tests/unit/utils/identifierUtils.test.ts
+++ b/tests/unit/utils/identifierUtils.test.ts
@@ -107,19 +107,6 @@ describe("warehouseRecordIdForExport", () => {
     ).toBe("wh-1");
   });
 
-  it("uses id on a GeoJSON Feature when _id is absent (Mapeo map features)", () => {
-    expect(
-      warehouseRecordIdForExport(
-        {
-          type: "Feature",
-          geometry: { type: "Point", coordinates: [0, 0] },
-          properties: { id: "0084cdc57c0b0280", name: "x" },
-        },
-        {},
-      ),
-    ).toBe("0084cdc57c0b0280");
-  });
-
   it("falls back to display row id when map feature has no _id", () => {
     expect(
       warehouseRecordIdForExport(

--- a/tests/unit/utils/identifierUtils.test.ts
+++ b/tests/unit/utils/identifierUtils.test.ts
@@ -8,6 +8,7 @@ import {
   titleToCamelCase,
   titleToSnakeCase,
   toCamelCase,
+  warehouseRecordIdForExport,
 } from "@/utils/identifierUtils";
 
 describe("sanitizeFilenameSegment", () => {
@@ -89,5 +90,35 @@ describe("snakeToTitleCase", () => {
 describe("titleToCamelCase", () => {
   it("converts spaced title text to camelCase", () => {
     expect(titleToCamelCase("Illegal Logging")).toBe("illegalLogging");
+  });
+});
+
+describe("warehouseRecordIdForExport", () => {
+  it("prefers _id from a GeoJSON Feature", () => {
+    expect(
+      warehouseRecordIdForExport(
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: { _id: "wh-1", name: "x" },
+        },
+        { id: "display-only" },
+      ),
+    ).toBe("wh-1");
+  });
+
+  it("falls back to display row id when map feature has no _id", () => {
+    expect(
+      warehouseRecordIdForExport(
+        { type: "Feature", geometry: null, properties: { name: "a" } },
+        { id: "99" },
+      ),
+    ).toBe("99");
+  });
+
+  it("falls back to display _id when geojson is not a Feature", () => {
+    expect(warehouseRecordIdForExport(undefined, { _id: "raw-2" })).toBe(
+      "raw-2",
+    );
   });
 });

--- a/tests/unit/utils/identifierUtils.test.ts
+++ b/tests/unit/utils/identifierUtils.test.ts
@@ -107,6 +107,19 @@ describe("warehouseRecordIdForExport", () => {
     ).toBe("wh-1");
   });
 
+  it("uses id on a GeoJSON Feature when _id is absent (Mapeo map features)", () => {
+    expect(
+      warehouseRecordIdForExport(
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: { id: "0084cdc57c0b0280", name: "x" },
+        },
+        {},
+      ),
+    ).toBe("0084cdc57c0b0280");
+  });
+
   it("falls back to display row id when map feature has no _id", () => {
     expect(
       warehouseRecordIdForExport(

--- a/utils/geoUtils.ts
+++ b/utils/geoUtils.ts
@@ -94,6 +94,16 @@ export const hasValidCoordinates = (
   });
 };
 
+/** Type guard for a GeoJSON Feature. */
+export const isGeoJsonFeature = (value: unknown): value is Feature => {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "type" in value &&
+    value.type === "Feature"
+  );
+};
+
 type Coordinate = [number, number];
 type LineString = Coordinate[];
 type Polygon = LineString[];

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -1,4 +1,5 @@
 import type { Feature } from "geojson";
+import type { AlertsData } from "@/types";
 
 /**
  * Strips combining diacritical marks after NFD normalization (ASCII-friendly identifiers).
@@ -99,31 +100,30 @@ export const titleToCamelCase = (str: string): string => {
  * @param displayFeature - Display row shown next to the map.
  * @returns {string | undefined} Warehouse id, or undefined if it cannot be resolved.
  */
-export const warehouseRecordIdForExport = (
-  featureGeojson: Feature | unknown,
-  displayFeature: Record<string, unknown>,
-): string | undefined => {
-  if (
-    featureGeojson &&
+const isGeoJsonFeature = (
+  featureGeojson?: Feature | AlertsData | null,
+): featureGeojson is Feature => {
+  return (
+    !!featureGeojson &&
     typeof featureGeojson === "object" &&
     "type" in featureGeojson &&
-    featureGeojson.type === "Feature" &&
-    "properties" in featureGeojson &&
-    featureGeojson.properties &&
-    typeof featureGeojson.properties === "object"
-  ) {
-    const wid = (featureGeojson.properties as Record<string, unknown>)._id;
-    if (wid != null && String(wid) !== "") {
-      return String(wid);
+    featureGeojson.type === "Feature"
+  );
+};
+
+export const warehouseRecordIdForExport = (
+  featureGeojson?: Feature | AlertsData | null,
+  displayFeature: Record<string, unknown> = {},
+): string | undefined => {
+  if (isGeoJsonFeature(featureGeojson)) {
+    const featureRecordId = String(featureGeojson.properties?._id ?? "").trim();
+    if (featureRecordId) {
+      return featureRecordId;
     }
   }
 
-  if (displayFeature._id != null && String(displayFeature._id) !== "") {
-    return String(displayFeature._id);
-  }
-  if (displayFeature.id != null && String(displayFeature.id) !== "") {
-    return String(displayFeature.id);
-  }
-
-  return undefined;
+  const displayRecordId = String(
+    displayFeature._id ?? displayFeature.id ?? "",
+  ).trim();
+  return displayRecordId || undefined;
 };

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -105,11 +105,7 @@ export const warehouseRecordIdForExport = (
   displayFeature: Record<string, unknown> = {},
 ): string | undefined => {
   if (isGeoJsonFeature(featureGeojson)) {
-    const props = featureGeojson.properties as
-      | Record<string, unknown>
-      | null
-      | undefined;
-    const featureRecordId = String(props?._id ?? props?.id ?? "").trim();
+    const featureRecordId = String(featureGeojson.properties?._id ?? "").trim();
     if (featureRecordId) {
       return featureRecordId;
     }

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -1,3 +1,5 @@
+import type { Feature } from "geojson";
+
 /**
  * Strips combining diacritical marks after NFD normalization (ASCII-friendly identifiers).
  *
@@ -87,4 +89,41 @@ export const titleToCamelCase = (str: string): string => {
       index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1),
     )
     .join("");
+};
+
+/**
+ * Resolves the warehouse `_id` for raw dataset export from a selected map row.
+ * Map GeoJSON features carry `_id` on `properties`; the sidebar row may expose `_id` or transformed `id`.
+ *
+ * @param featureGeojson - Optional map selection (only GeoJSON Features are read).
+ * @param displayFeature - Display row shown next to the map.
+ * @returns {string | undefined} Warehouse id, or undefined if it cannot be resolved.
+ */
+export const warehouseRecordIdForExport = (
+  featureGeojson: Feature | unknown,
+  displayFeature: Record<string, unknown>,
+): string | undefined => {
+  if (
+    featureGeojson &&
+    typeof featureGeojson === "object" &&
+    "type" in featureGeojson &&
+    featureGeojson.type === "Feature" &&
+    "properties" in featureGeojson &&
+    featureGeojson.properties &&
+    typeof featureGeojson.properties === "object"
+  ) {
+    const wid = (featureGeojson.properties as Record<string, unknown>)._id;
+    if (wid != null && String(wid) !== "") {
+      return String(wid);
+    }
+  }
+
+  if (displayFeature._id != null && String(displayFeature._id) !== "") {
+    return String(displayFeature._id);
+  }
+  if (displayFeature.id != null && String(displayFeature.id) !== "") {
+    return String(displayFeature.id);
+  }
+
+  return undefined;
 };

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -105,7 +105,11 @@ export const warehouseRecordIdForExport = (
   displayFeature: Record<string, unknown> = {},
 ): string | undefined => {
   if (isGeoJsonFeature(featureGeojson)) {
-    const featureRecordId = String(featureGeojson.properties?._id ?? "").trim();
+    const props = featureGeojson.properties as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    const featureRecordId = String(props?._id ?? props?.id ?? "").trim();
     if (featureRecordId) {
       return featureRecordId;
     }

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -1,5 +1,5 @@
-import type { Feature } from "geojson";
 import type { AlertsData } from "@/types";
+import { isGeoJsonFeature } from "@/utils/geoUtils";
 
 /**
  * Strips combining diacritical marks after NFD normalization (ASCII-friendly identifiers).
@@ -100,19 +100,8 @@ export const titleToCamelCase = (str: string): string => {
  * @param displayFeature - Display row shown next to the map.
  * @returns {string | undefined} Warehouse id, or undefined if it cannot be resolved.
  */
-const isGeoJsonFeature = (
-  featureGeojson?: Feature | AlertsData | null,
-): featureGeojson is Feature => {
-  return (
-    !!featureGeojson &&
-    typeof featureGeojson === "object" &&
-    "type" in featureGeojson &&
-    featureGeojson.type === "Feature"
-  );
-};
-
 export const warehouseRecordIdForExport = (
-  featureGeojson?: Feature | AlertsData | null,
+  featureGeojson?: AlertsData | null | unknown,
   displayFeature: Record<string, unknown> = {},
 ): string | undefined => {
   if (isGeoJsonFeature(featureGeojson)) {


### PR DESCRIPTION
## Goal

Fix individual map-record downloads so CSV, GeoJSON, and KML include the full raw warehouse row instead of only the reduced map feature properties. Closes #411 

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-04-13 at 09 59 46" src="https://github.com/user-attachments/assets/39878c4d-4aa5-40c7-b3ee-89deca646f05" />
<img width="1470" height="956" alt="Screenshot 2026-04-13 at 09 59 27" src="https://github.com/user-attachments/assets/7b442273-a2ef-4fe2-9164-dc3e23ba54e5" />


## What I changed and why

I updated the export endpoint to accept an optional `recordId` and scope the export to a single warehouse row when present. The sidebar download flow now passes that record id through to the existing export endpoint, This keeps CSV, GeoJSON, and KML behavior consistent and ensures per-record downloads include the same raw attributes users expect from full exports.

## What I'm not doing here

I am not introducing a new export endpoint.
I am not changing the bulk export format beyond reusing its raw-row behavior for single-record downloads.

## LLM use disclosure

Reasoned with GPT 5.4