### PR TITLE
193.1: Define new view config table structure per view type

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,6 +120,9 @@ export default defineNuxtConfig({
     dbSsl: true,
     dbTable: "",
     port: "8080",
+    maxAlertsSecondaryDatasets: 1,
+    maxMapSecondaryDatasets: 2,
+    maxGallerySecondaryDatasets: 0,
     // Session secret for nuxt-auth-utils
     sessionSecret: "your-session-secret-key-change-in-production",
     // OAuth configuration for nuxt-auth-utils

--- a/server/database/migrations/0007_create_view_type_config_tables.sql
+++ b/server/database/migrations/0007_create_view_type_config_tables.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS "view_config_alerts" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  "secondary_dataset" text,
+  CONSTRAINT "view_config_alerts_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "view_config_map" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  "secondary_datasets" text,
+  CONSTRAINT "view_config_map_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "view_config_gallery" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  CONSTRAINT "view_config_gallery_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1768207769008,
       "tag": "0006_backfill_parent_alerts_table_incidents",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776729600000,
+      "tag": "0007_create_view_type_config_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,5 +1,10 @@
 // Import all schemas
 import { viewConfig } from "./schemas/viewConfig";
+import {
+  viewConfigAlerts,
+  viewConfigMap,
+  viewConfigGallery,
+} from "./schemas/viewConfigByType";
 import { publicViews } from "./schemas/publicViews";
 import {
   annotatedCollections,
@@ -9,11 +14,15 @@ import {
 
 // Re-export all schemas from separate files
 export * from "./schemas/viewConfig";
+export * from "./schemas/viewConfigByType";
 export * from "./schemas/publicViews";
 export * from "./schemas/annotatedCollections";
 
 export const schemas = {
   viewConfig,
+  viewConfigAlerts,
+  viewConfigMap,
+  viewConfigGallery,
   publicViews,
   annotatedCollections,
   incidents,

--- a/server/database/schemas/viewConfigByType.ts
+++ b/server/database/schemas/viewConfigByType.ts
@@ -1,0 +1,27 @@
+import { pgTable, text } from "drizzle-orm/pg-core";
+
+import { viewConfig } from "./viewConfig";
+
+export const viewConfigAlerts = pgTable("view_config_alerts", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+  secondaryDataset: text("secondary_dataset"),
+});
+
+export const viewConfigMap = pgTable("view_config_map", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+  // Keep this list-based to avoid schema migrations when max changes.
+  secondaryDatasets: text("secondary_datasets"),
+});
+
+export const viewConfigGallery = pgTable("view_config_gallery", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+});

--- a/server/utils/dbHelpers.ts
+++ b/server/utils/dbHelpers.ts
@@ -36,3 +36,38 @@ export const parseAndValidateLimit = (event: H3Event): number => {
   const maxLimit = Number(useRuntimeConfig(event).public.rowLimit);
   return validateRowLimit(raw, maxLimit);
 };
+
+/**
+ * Parses a comma-separated secondary dataset list into a normalized array.
+ * Keeps first occurrence order, removes blanks, deduplicates, and enforces max.
+ */
+export const getSecondaryDatasets = (input: unknown, max = 2): string[] => {
+  if (typeof input !== "string" || max <= 0) {
+    return [];
+  }
+
+  const values = input
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  const unique: string[] = [];
+  for (const value of values) {
+    if (!unique.includes(value)) {
+      unique.push(value);
+    }
+  }
+
+  return unique.slice(0, max);
+};
+
+/**
+ * Converts secondary datasets to storage form for `view_config_map.secondary_datasets`.
+ */
+export const normalizeSecondaryDatasets = (
+  input: unknown,
+  max = 2,
+): string | null => {
+  const datasets = getSecondaryDatasets(input, max);
+  return datasets.length > 0 ? datasets.join(",") : null;
+};

--- a/tests/unit/server/secondaryDatasets.test.ts
+++ b/tests/unit/server/secondaryDatasets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSecondaryDatasets,
+  normalizeSecondaryDatasets,
+} from "@/server/utils/dbHelpers";
+
+describe("getSecondaryDatasets", () => {
+  it("returns empty array for non-string inputs", () => {
+    expect(getSecondaryDatasets(undefined)).toEqual([]);
+    expect(getSecondaryDatasets(null)).toEqual([]);
+    expect(getSecondaryDatasets(123)).toEqual([]);
+  });
+
+  it("parses, trims and removes blanks", () => {
+    expect(getSecondaryDatasets("  foo, bar ,, baz  ", 10)).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  it("deduplicates while preserving first-seen order", () => {
+    expect(getSecondaryDatasets("foo,bar,foo,baz,bar", 10)).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  it("enforces max datasets", () => {
+    expect(getSecondaryDatasets("a,b,c,d", 2)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array when max is 0 or less", () => {
+    expect(getSecondaryDatasets("a,b", 0)).toEqual([]);
+    expect(getSecondaryDatasets("a,b", -1)).toEqual([]);
+  });
+});
+
+describe("normalizeSecondaryDatasets", () => {
+  it("serializes normalized datasets as comma-separated string", () => {
+    expect(normalizeSecondaryDatasets("a,b,a,c", 2)).toBe("a,b");
+  });
+
+  it("returns null when no valid secondary datasets", () => {
+    expect(normalizeSecondaryDatasets(" , ", 2)).toBeNull();
+    expect(normalizeSecondaryDatasets(undefined, 2)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Goal

Implement subissue 193.1 by defining new per-view-type config tables in Drizzle as a schema-only change, establishing a stable target for follow-up migration/API work. Closes #416 

## Screenshots

<img width="212" height="70" alt="Screenshot 2026-04-21 at 15 55 38" src="https://github.com/user-attachments/assets/b784a5d9-67e7-4f86-b27c-5495db4af69e" />

## What I changed and why

Added new Drizzle schema definitions for `view_config_alerts`, `view_config_map`, and `view_config_gallery` in `server/database/schemas/viewConfigByType.ts`, each with a `view_id` FK to `view_config` with `ON DELETE CASCADE`, plus type-appropriate primary/secondary dataset columns. Per Rudo's feedback, map config uses a single `secondary_datasets` list string rather than fixed `secondary_dataset_1/2` columns to avoid future migration churn if limits change. Updated `server/database/schema.ts` to register the new tables and added the corresponding migration (`0007_create_view_type_config_tables.sql`) with a journal entry. Runtime ceiling knobs for each view type (`maxAlertsSecondaryDatasets`, `maxMapSecondaryDatasets`, `maxGallerySecondaryDatasets`) land in `nuxt.config.ts`, backed by `getSecondaryDatasets` and `normalizeSecondaryDatasets` utilities in `server/utils/dbHelpers.ts` with unit test coverage.

## What I'm not doing here

- No data migration from legacy `view_config.views_config` yet.
- No API persistence/read-path wiring for new tables yet.
- No deletion or mutation of legacy config rows.

## LLM use disclosure
None