### PR TITLE
193.2: Migrate alerts config to view_config_alerts

### DIFF
--- a/server/database/migrations/0008_backfill_view_config_alerts.sql
+++ b/server/database/migrations/0008_backfill_view_config_alerts.sql
@@ -1,0 +1,23 @@
+-- Backfill alert view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_alerts" (
+  "view_id",
+  "primary_dataset",
+  "secondary_dataset"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset",
+  NULLIF(BTRIM((vc."views_config"::jsonb ->> 'MAPEO_TABLE')), '') AS "secondary_dataset"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'alerts'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776729600000,
       "tag": "0007_create_view_type_config_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776816000000,
+      "tag": "0008_backfill_view_config_alerts",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Goal

Implement subissue 193.2 by migrating legacy alerts view dataset linkage from `view_config.views_config` JSON into first-class columns in `view_config_alerts`. Closes #417 

## Screenshots

N/A (migration-only change)

## What I changed and why

Added `0008_backfill_view_config_alerts.sql` to backfill `view_config_alerts` from existing `view_config` rows where the JSON `VIEWS` column includes `alerts`. Each row maps `view_id` and `primary_dataset` to `table_name`, with `secondary_dataset` set to the trimmed `MAPEO_TABLE` value (empty strings coerced to `NULL`). The insert uses `ON CONFLICT ("view_id") DO NOTHING` to keep reruns safe. `MAPEO_TABLE` is the right source for secondary dataset here since the current alerts API already treats it as the optional secondary source fetched alongside the primary alerts table — `DATASET_TABLE` is a display label, not a table identifier. Migration journal updated accordingly.

## What I'm not doing here

- No deletion/modification of legacy `view_config` rows.
- No migration for map/gallery configs in this PR.

## LLM use disclosure

Used LLM assistance for drafting SQL migration logic.