### PR TITLE
193.3: Update alerts API to read from new config table

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchAlertsViewDatasets,
+  fetchData,
+  fetchTableConfig,
+} from "@/server/database/dbOperations";
 import murmurhash from "murmurhash";
 import {
   prepareAlertsStatistics,
@@ -28,6 +32,9 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset, secondaryDataset } = await fetchAlertsViewDatasets(
+      table,
+    );
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -36,7 +43,7 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, metadata } = (await fetchData(table, limit)) as {
+    const { mainData, metadata } = (await fetchData(primaryDataset, limit)) as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];
     };
@@ -60,7 +67,7 @@ export default defineEventHandler(async (event: H3Event) => {
       ),
     };
 
-    const mapeoTable = tableConfig.MAPEO_TABLE;
+    const mapeoTable = secondaryDataset;
     const mapeoCategoryIds = tableConfig.MAPEO_CATEGORY_IDS;
 
     let mapeoData: FeatureCollection | null = null;
@@ -125,6 +132,8 @@ export default defineEventHandler(async (event: H3Event) => {
       mapboxStyle: defaultMapboxStyle,
       mapboxBasemaps: basemaps,
       mapboxZoom: Number(tableConfig.MAPBOX_ZOOM),
+      primary_dataset: primaryDataset,
+      secondary_dataset: secondaryDataset,
       mapeoTable,
       mapeoData,
       mediaBasePath: tableConfig.MEDIA_BASE_PATH,

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,5 +1,5 @@
 import {
-  fetchAlertsViewDatasets,
+  fetchViewDatasets,
   fetchData,
   fetchTableConfig,
 } from "@/server/database/dbOperations";
@@ -32,9 +32,11 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
-    const { primaryDataset, secondaryDataset } = await fetchAlertsViewDatasets(
+    const { primaryDataset, secondaryDatasets } = await fetchViewDatasets(
       table,
+      "alerts",
     );
+    const secondaryDataset = secondaryDatasets[0] ?? null;
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -10,6 +10,8 @@ import type {
   ViewType,
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
+import { splitCsv } from "@/utils/csvUtils";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 
 import {
   viewConfig,
@@ -49,6 +51,79 @@ const createMissingViewDatasetConfigError = (
   error.statusCode = 404;
   error.statusMessage = statusMessage;
   return error;
+};
+
+type ViewDatasetSpec = {
+  table:
+    | typeof viewConfigAlerts
+    | typeof viewConfigMap
+    | typeof viewConfigGallery;
+  viewIdColumn:
+    | typeof viewConfigAlerts.viewId
+    | typeof viewConfigMap.viewId
+    | typeof viewConfigGallery.viewId;
+  primaryColumn:
+    | typeof viewConfigAlerts.primaryDataset
+    | typeof viewConfigMap.primaryDataset
+    | typeof viewConfigGallery.primaryDataset;
+  secondarySelections?: Record<string, AnyPgColumn>;
+  extractSecondary?: (row: Record<string, unknown>) => string[];
+};
+
+const VIEW_DATASET_SPECS: Record<ViewType, ViewDatasetSpec> = {
+  alerts: {
+    table: viewConfigAlerts,
+    viewIdColumn: viewConfigAlerts.viewId,
+    primaryColumn: viewConfigAlerts.primaryDataset,
+    secondarySelections: {
+      secondaryDataset: viewConfigAlerts.secondaryDataset,
+    },
+    extractSecondary: (row) => {
+      const value = row.secondaryDataset;
+      return typeof value === "string" && value.length > 0 ? [value] : [];
+    },
+  },
+  map: {
+    table: viewConfigMap,
+    viewIdColumn: viewConfigMap.viewId,
+    primaryColumn: viewConfigMap.primaryDataset,
+    secondarySelections: { secondaryDatasets: viewConfigMap.secondaryDatasets },
+    extractSecondary: (row) =>
+      splitCsv(
+        typeof row.secondaryDatasets === "string"
+          ? row.secondaryDatasets
+          : null,
+      ),
+  },
+  gallery: {
+    table: viewConfigGallery,
+    viewIdColumn: viewConfigGallery.viewId,
+    primaryColumn: viewConfigGallery.primaryDataset,
+  },
+};
+
+const queryViewDatasets = async (
+  spec: ViewDatasetSpec,
+  viewId: string,
+): Promise<ViewDatasets | null> => {
+  const [row] = (await configDb
+    .select({
+      primaryDataset: spec.primaryColumn,
+      ...(spec.secondarySelections ?? {}),
+    })
+    .from(spec.table)
+    .where(eq(spec.viewIdColumn, viewId))
+    .limit(1)) as Array<Record<string, unknown>>;
+
+  const primary = row?.primaryDataset;
+  if (typeof primary !== "string" || primary.length === 0) {
+    return null;
+  }
+
+  return {
+    primaryDataset: primary,
+    secondaryDatasets: spec.extractSecondary?.(row) ?? [],
+  };
 };
 
 /**
@@ -387,12 +462,22 @@ export const fetchTableConfig = async (table: string): Promise<ViewConfig> => {
 };
 
 /**
- * Fetches dataset linkage for one table from view-type-specific config tables.
+ * Resolves dataset table linkage for a single view instance.
  *
- * @param {string} table - View identifier.
- * @param {ViewType} viewType - View type table to query.
- * @returns {Promise<ViewDatasets>} Primary and secondary dataset names.
- * @throws {Error} When dataset config is missing.
+ * This is the shared lookup used by all view endpoints that need to know which
+ * warehouse table(s) to query. It reads from the per-view-type config tables
+ * (`view_config_alerts`, `view_config_map`, `view_config_gallery`) and returns a
+ * normalized shape (`primaryDataset`, `secondaryDatasets[]`) for route handlers.
+ *
+ * Typical usage:
+ * - alerts endpoint: `fetchViewDatasets(table, "alerts")`
+ * - map endpoint: `fetchViewDatasets(table, "map")`
+ * - gallery endpoint: `fetchViewDatasets(table, "gallery")`
+ *
+ * @param {string} table - View identifier (currently `view_id` / route table param).
+ * @param {ViewType} viewType - Which view config table should be queried.
+ * @returns {Promise<ViewDatasets>} Normalized primary + secondary dataset list.
+ * @throws {Error} 404-style error when no dataset config exists for that view.
  */
 export const fetchViewDatasets = async (
   table: string,
@@ -417,69 +502,14 @@ export const fetchViewDatasets = async (
   }
 
   try {
-    if (viewType === "alerts") {
-      const result = await configDb
-        .select({
-          primaryDataset: viewConfigAlerts.primaryDataset,
-          secondaryDataset: viewConfigAlerts.secondaryDataset,
-        })
-        .from(viewConfigAlerts)
-        .where(eq(viewConfigAlerts.viewId, table))
-        .limit(1);
-
-      if (result.length === 0 || !result[0].primaryDataset) {
-        throw createMissingViewDatasetConfigError(table, viewType);
-      }
-
-      return {
-        primaryDataset: result[0].primaryDataset,
-        secondaryDatasets: result[0].secondaryDataset
-          ? [result[0].secondaryDataset]
-          : [],
-      };
-    }
-
-    if (viewType === "map") {
-      const result = await configDb
-        .select({
-          primaryDataset: viewConfigMap.primaryDataset,
-          secondaryDatasets: viewConfigMap.secondaryDatasets,
-        })
-        .from(viewConfigMap)
-        .where(eq(viewConfigMap.viewId, table))
-        .limit(1);
-
-      if (result.length === 0 || !result[0].primaryDataset) {
-        throw createMissingViewDatasetConfigError(table, viewType);
-      }
-
-      const secondaryDatasets = (result[0].secondaryDatasets ?? "")
-        .split(",")
-        .map((value) => value.trim())
-        .filter((value) => value.length > 0);
-
-      return {
-        primaryDataset: result[0].primaryDataset,
-        secondaryDatasets,
-      };
-    }
-
-    const result = await configDb
-      .select({
-        primaryDataset: viewConfigGallery.primaryDataset,
-      })
-      .from(viewConfigGallery)
-      .where(eq(viewConfigGallery.viewId, table))
-      .limit(1);
-
-    if (result.length === 0 || !result[0].primaryDataset) {
+    const datasets = await queryViewDatasets(
+      VIEW_DATASET_SPECS[viewType],
+      table,
+    );
+    if (!datasets) {
       throw createMissingViewDatasetConfigError(table, viewType);
     }
-
-    return {
-      primaryDataset: result[0].primaryDataset,
-      secondaryDatasets: [],
-    };
+    return datasets;
   } catch (error) {
     if (error instanceof Error && "statusCode" in error) {
       throw error;

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from "drizzle-orm";
 
 import type {
+  AlertsViewDatasets,
   ColumnEntry,
   DataEntry,
   RouteLevelPermission,
@@ -9,7 +10,7 @@ import type {
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
 
-import { viewConfig, publicViews } from "./schema";
+import { viewConfig, viewConfigAlerts, publicViews } from "./schema";
 import { configDb, warehouseDb } from "./dbConnection";
 
 /**
@@ -20,6 +21,17 @@ import { configDb, warehouseDb } from "./dbConnection";
  */
 const createMissingViewConfigError = (table: string) => {
   const statusMessage = `No view configuration found for table "${table}"`;
+  const error = new Error(statusMessage) as Error & {
+    statusCode: number;
+    statusMessage: string;
+  };
+  error.statusCode = 404;
+  error.statusMessage = statusMessage;
+  return error;
+};
+
+const createMissingAlertsDatasetConfigError = (table: string) => {
+  const statusMessage = `No alerts dataset configuration found for table "${table}"`;
   const error = new Error(statusMessage) as Error & {
     statusCode: number;
     statusMessage: string;
@@ -360,6 +372,56 @@ export const fetchTableConfig = async (table: string): Promise<ViewConfig> => {
       throw error;
     }
     console.error(`Error fetching config for table "${table}":`, error);
+    throw error;
+  }
+};
+
+/**
+ * Fetches alerts dataset linkage for one table from view_config_alerts.
+ *
+ * @param {string} table - Alerts view identifier.
+ * @returns {Promise<AlertsViewDatasets>} Primary and optional secondary dataset names.
+ * @throws {Error} When alerts dataset config is missing.
+ */
+export const fetchAlertsViewDatasets = async (
+  table: string,
+): Promise<AlertsViewDatasets> => {
+  if (process.env.CI) {
+    const viewsConfig = await fetchConfig();
+    const tableConfig = viewsConfig[table];
+    if (!tableConfig) {
+      throw createMissingAlertsDatasetConfigError(table);
+    }
+
+    return {
+      primaryDataset: table,
+      secondaryDataset: tableConfig.MAPEO_TABLE ?? null,
+    };
+  }
+
+  try {
+    const result = await configDb
+      .select({
+        primaryDataset: viewConfigAlerts.primaryDataset,
+        secondaryDataset: viewConfigAlerts.secondaryDataset,
+      })
+      .from(viewConfigAlerts)
+      .where(eq(viewConfigAlerts.viewId, table))
+      .limit(1);
+
+    if (result.length === 0 || !result[0].primaryDataset) {
+      throw createMissingAlertsDatasetConfigError(table);
+    }
+
+    return {
+      primaryDataset: result[0].primaryDataset,
+      secondaryDataset: result[0].secondaryDataset,
+    };
+  } catch (error) {
+    if (error instanceof Error && "statusCode" in error) {
+      throw error;
+    }
+    console.error(`Error fetching alerts datasets for table "${table}":`, error);
     throw error;
   }
 };

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -1,16 +1,23 @@
 import { eq, sql } from "drizzle-orm";
 
 import type {
-  AlertsViewDatasets,
   ColumnEntry,
   DataEntry,
   RouteLevelPermission,
+  ViewDatasets,
   Views,
   ViewConfig,
+  ViewType,
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
 
-import { viewConfig, viewConfigAlerts, publicViews } from "./schema";
+import {
+  viewConfig,
+  viewConfigAlerts,
+  viewConfigGallery,
+  viewConfigMap,
+  publicViews,
+} from "./schema";
 import { configDb, warehouseDb } from "./dbConnection";
 
 /**
@@ -30,8 +37,11 @@ const createMissingViewConfigError = (table: string) => {
   return error;
 };
 
-const createMissingAlertsDatasetConfigError = (table: string) => {
-  const statusMessage = `No alerts dataset configuration found for table "${table}"`;
+const createMissingViewDatasetConfigError = (
+  table: string,
+  viewType: ViewType,
+) => {
+  const statusMessage = `No ${viewType} dataset configuration found for table "${table}"`;
   const error = new Error(statusMessage) as Error & {
     statusCode: number;
     statusMessage: string;
@@ -377,51 +387,107 @@ export const fetchTableConfig = async (table: string): Promise<ViewConfig> => {
 };
 
 /**
- * Fetches alerts dataset linkage for one table from view_config_alerts.
+ * Fetches dataset linkage for one table from view-type-specific config tables.
  *
- * @param {string} table - Alerts view identifier.
- * @returns {Promise<AlertsViewDatasets>} Primary and optional secondary dataset names.
- * @throws {Error} When alerts dataset config is missing.
+ * @param {string} table - View identifier.
+ * @param {ViewType} viewType - View type table to query.
+ * @returns {Promise<ViewDatasets>} Primary and secondary dataset names.
+ * @throws {Error} When dataset config is missing.
  */
-export const fetchAlertsViewDatasets = async (
+export const fetchViewDatasets = async (
   table: string,
-): Promise<AlertsViewDatasets> => {
+  viewType: ViewType,
+): Promise<ViewDatasets> => {
   if (process.env.CI) {
     const viewsConfig = await fetchConfig();
     const tableConfig = viewsConfig[table];
     if (!tableConfig) {
-      throw createMissingAlertsDatasetConfigError(table);
+      throw createMissingViewDatasetConfigError(table, viewType);
     }
+
+    const secondaryDatasets =
+      viewType === "alerts" && tableConfig.MAPEO_TABLE
+        ? [tableConfig.MAPEO_TABLE]
+        : [];
 
     return {
       primaryDataset: table,
-      secondaryDataset: tableConfig.MAPEO_TABLE ?? null,
+      secondaryDatasets,
     };
   }
 
   try {
+    if (viewType === "alerts") {
+      const result = await configDb
+        .select({
+          primaryDataset: viewConfigAlerts.primaryDataset,
+          secondaryDataset: viewConfigAlerts.secondaryDataset,
+        })
+        .from(viewConfigAlerts)
+        .where(eq(viewConfigAlerts.viewId, table))
+        .limit(1);
+
+      if (result.length === 0 || !result[0].primaryDataset) {
+        throw createMissingViewDatasetConfigError(table, viewType);
+      }
+
+      return {
+        primaryDataset: result[0].primaryDataset,
+        secondaryDatasets: result[0].secondaryDataset
+          ? [result[0].secondaryDataset]
+          : [],
+      };
+    }
+
+    if (viewType === "map") {
+      const result = await configDb
+        .select({
+          primaryDataset: viewConfigMap.primaryDataset,
+          secondaryDatasets: viewConfigMap.secondaryDatasets,
+        })
+        .from(viewConfigMap)
+        .where(eq(viewConfigMap.viewId, table))
+        .limit(1);
+
+      if (result.length === 0 || !result[0].primaryDataset) {
+        throw createMissingViewDatasetConfigError(table, viewType);
+      }
+
+      const secondaryDatasets = (result[0].secondaryDatasets ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+      return {
+        primaryDataset: result[0].primaryDataset,
+        secondaryDatasets,
+      };
+    }
+
     const result = await configDb
       .select({
-        primaryDataset: viewConfigAlerts.primaryDataset,
-        secondaryDataset: viewConfigAlerts.secondaryDataset,
+        primaryDataset: viewConfigGallery.primaryDataset,
       })
-      .from(viewConfigAlerts)
-      .where(eq(viewConfigAlerts.viewId, table))
+      .from(viewConfigGallery)
+      .where(eq(viewConfigGallery.viewId, table))
       .limit(1);
 
     if (result.length === 0 || !result[0].primaryDataset) {
-      throw createMissingAlertsDatasetConfigError(table);
+      throw createMissingViewDatasetConfigError(table, viewType);
     }
 
     return {
       primaryDataset: result[0].primaryDataset,
-      secondaryDataset: result[0].secondaryDataset,
+      secondaryDatasets: [],
     };
   } catch (error) {
     if (error instanceof Error && "statusCode" in error) {
       throw error;
     }
-    console.error(`Error fetching alerts datasets for table "${table}":`, error);
+    console.error(
+      `Error fetching ${viewType} datasets for table "${table}":`,
+      error,
+    );
     throw error;
   }
 };

--- a/tests/unit/server/alertsEndpointDatasets.test.ts
+++ b/tests/unit/server/alertsEndpointDatasets.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockFetchAlertsViewDatasets = vi.fn();
+const mockFetchViewDatasets = vi.fn();
 const mockFetchTableConfig = vi.fn();
 const mockFetchData = vi.fn();
 const mockValidatePermissions = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
-  fetchAlertsViewDatasets: (table: string) => mockFetchAlertsViewDatasets(table),
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
   fetchTableConfig: (table: string) => mockFetchTableConfig(table),
   fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
 }));
@@ -83,19 +84,23 @@ describe("alerts endpoint dataset config", () => {
   });
 
   it("returns structured dataset fields and tolerates null secondary dataset", async () => {
-    mockFetchAlertsViewDatasets.mockResolvedValue({
+    mockFetchViewDatasets.mockResolvedValue({
       primaryDataset: "alerts_confidential",
-      secondaryDataset: null,
+      secondaryDatasets: [],
     });
 
     const { default: handler } = await import("@/server/api/[table]/alerts");
-    const response = await handler({
+    const response = (await handler({
       context: { params: { table: "alerts_confidential" } },
-    } as never);
+    } as never)) as Record<string, unknown>;
 
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "alerts_confidential",
+      "alerts",
+    );
     expect(mockFetchData).toHaveBeenCalledWith("alerts_confidential", 100);
     expect(mockFetchData).toHaveBeenCalledTimes(1);
-    expect(response.primary_dataset).toBe("alerts_confidential");
-    expect(response.secondary_dataset).toBeNull();
+    expect(response["primary_dataset"]).toBe("alerts_confidential");
+    expect(response["secondary_dataset"]).toBeNull();
   });
 });

--- a/tests/unit/server/alertsEndpointDatasets.test.ts
+++ b/tests/unit/server/alertsEndpointDatasets.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchAlertsViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchAlertsViewDatasets: (table: string) => mockFetchAlertsViewDatasets(table),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils", () => ({
+  parseBasemaps: () => ({
+    basemaps: [],
+    defaultMapboxStyle: "mapbox://styles/mapbox/streets-v12",
+  }),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 100,
+}));
+
+vi.mock("@/server/dataProcessing/dataTransformers", () => ({
+  prepareMinimalAlertEntries: (mainData: unknown[]) => ({
+    mostRecentAlerts: mainData,
+    previousAlerts: [],
+  }),
+  prepareAlertsStatistics: () => ({ alertsTotal: 0 }),
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterUnwantedKeys: (rows: unknown[]) => rows,
+  filterGeoData: (rows: unknown[]) => rows,
+}));
+
+vi.mock("@/utils/geoUtils", () => ({
+  buildMinimalFeatureCollection: () => ({
+    type: "FeatureCollection",
+    features: [],
+  }),
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("alerts endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "anyone",
+      MAPEO_CATEGORY_IDS: "threat",
+      MAPBOX_3D: false,
+      MAPBOX_ZOOM: 7,
+      MAPBOX_BEARING: 0,
+      MAPBOX_CENTER_LATITUDE: "0",
+      MAPBOX_CENTER_LONGITUDE: "0",
+      MAPBOX_PITCH: 0,
+      MAPBOX_PROJECTION: "globe",
+      MAPBOX_ACCESS_TOKEN: "token",
+      MAPBOX_STYLE: "mapbox://styles/mapbox/streets-v12",
+      MEDIA_BASE_PATH: "",
+      MEDIA_BASE_PATH_ALERTS: "",
+      PLANET_API_KEY: "",
+    });
+
+    mockFetchData.mockResolvedValue({
+      mainData: [{ _id: "1", alertID: "a1" }],
+      columnsData: null,
+      metadata: [],
+    });
+  });
+
+  it("returns structured dataset fields and tolerates null secondary dataset", async () => {
+    mockFetchAlertsViewDatasets.mockResolvedValue({
+      primaryDataset: "alerts_confidential",
+      secondaryDataset: null,
+    });
+
+    const { default: handler } = await import("@/server/api/[table]/alerts");
+    const response = await handler({
+      context: { params: { table: "alerts_confidential" } },
+    } as never);
+
+    expect(mockFetchData).toHaveBeenCalledWith("alerts_confidential", 100);
+    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(response.primary_dataset).toBe("alerts_confidential");
+    expect(response.secondary_dataset).toBeNull();
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -66,6 +66,11 @@ export interface Views {
   [key: string]: ViewConfig;
 }
 
+export interface AlertsViewDatasets {
+  primaryDataset: string;
+  secondaryDataset: string | null;
+}
+
 export type AllowedFileExtensions = {
   audio: string[];
   image: string[];

--- a/types/index.ts
+++ b/types/index.ts
@@ -66,9 +66,11 @@ export interface Views {
   [key: string]: ViewConfig;
 }
 
-export interface AlertsViewDatasets {
+export type ViewType = "alerts" | "map" | "gallery";
+
+export interface ViewDatasets {
   primaryDataset: string;
-  secondaryDataset: string | null;
+  secondaryDatasets: string[];
 }
 
 export type AllowedFileExtensions = {

--- a/utils/csvUtils.ts
+++ b/utils/csvUtils.ts
@@ -23,6 +23,16 @@ export const escapeCSVValue = (value: unknown): string => {
 };
 
 /**
+ * Splits comma-separated values into a trimmed non-empty list.
+ * Useful for config fields that store list-like values in one text column.
+ */
+export const splitCsv = (value: string | null | undefined): string[] =>
+  (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+/**
  * Builds a CSV string from tabular rows with a fixed header order (like dataset export).
  * Objects and arrays are JSON-stringified for a single cell.
  */


### PR DESCRIPTION
## Goal

Implement subissue 193.3 by making the alerts API read dataset linkage from `view_config_alerts` and return explicit dataset fields. Closes #418 

## Screenshots

N/A (API-only change)

## What I changed and why

- Created a generic config accessor in `server/database/dbOperations.ts`:
  - Added `fetchViewDatasets(table, viewType)` for `alerts`, `map`, and `gallery`.
  - Added generic missing-config error helper (`createMissingViewDatasetConfigError`).
- Introduced generic types in `types/index.ts`:
  - `ViewType`
  - `ViewDatasets`
- Updated `server/api/[table]/alerts.ts` to use `fetchViewDatasets(table, "alerts")` 
- Preserved explicit API response fields for frontend use:
  - `primary_dataset`
  - `secondary_dataset` (nullable)
- Updated unit test `tests/unit/server/alertsEndpointDatasets.test.ts` to validate:
  - generic accessor is called with `("alerts_confidential", "alerts")`
  - null secondary dataset is handled without breaking API response.

This keeps the 193.3 scope working while aligning implementation with the epic’s reusable architecture direction.

## What I'm not doing here

- No removal of other legacy alert display/config fields yet.
- No map/gallery endpoint migration in this PR.

## LLM use disclosure

Used LLM assistance in writing tests