### PR TITLE
Push Column Projection to DB for `fetchData` (Eliminate Full-Table Loads)

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -37,6 +37,29 @@ const ALERTS_MAIN_PROJECTION = [
   "g__coordinates",
 ];
 
+/**
+ * Keeps preferred projection columns that exist on the target table.
+ * Falls back to all available columns when none of the preferred columns exist.
+ *
+ * @param {string[]} preferredColumns - Columns this route wants to project.
+ * @param {string[]} availableColumns - Columns available on the target table.
+ * @returns {string[]} Safe projection columns to send to fetchData.
+ */
+const resolveProjectedColumns = (
+  preferredColumns: string[],
+  availableColumns: string[],
+): string[] => {
+  const projectedColumns = preferredColumns.filter((columnName) =>
+    availableColumns.includes(columnName),
+  );
+
+  if (projectedColumns.length > 0) {
+    return projectedColumns;
+  }
+
+  return availableColumns;
+};
+
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
   const limit = parseAndValidateLimit(event);
@@ -56,11 +79,23 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
+    const availableMainColumns = await fetchTableSqlColumns(table);
+    const alertsMainProjection = resolveProjectedColumns(
+      ALERTS_MAIN_PROJECTION,
+      availableMainColumns,
+    );
+    const availableMetadataColumns = await fetchTableSqlColumns(
+      `${table}__metadata`,
+    );
+    const alertsMetadataProjection = ALERTS_METADATA_PROJECTION.filter(
+      (columnName) => availableMetadataColumns.includes(columnName),
+    );
+
     const { mainData, metadata } = (await fetchData(table, {
       limit,
-      mainColumns: ALERTS_MAIN_PROJECTION,
-      includeMetadata: true,
-      metadataColumns: ALERTS_METADATA_PROJECTION,
+      mainColumns: alertsMainProjection,
+      includeMetadata: alertsMetadataProjection.length > 0,
+      metadataColumns: alertsMetadataProjection,
     })) as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,4 +1,9 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  ALERTS_METADATA_PROJECTION,
+  fetchData,
+  fetchTableConfig,
+  fetchTableSqlColumns,
+} from "@/server/database/dbOperations";
 import murmurhash from "murmurhash";
 import {
   prepareAlertsStatistics,
@@ -16,6 +21,21 @@ import { parseAndValidateLimit } from "@/server/utils/dbHelpers";
 import type { H3Event } from "h3";
 import type { AllowedFileExtensions, DataEntry, AlertsMetadata } from "@/types";
 import type { FeatureCollection } from "geojson";
+
+const ALERTS_MAIN_PROJECTION = [
+  "_id",
+  "alert_id",
+  "month_detec",
+  "year_detec",
+  "day_detec",
+  "date_end_t1",
+  "data_source",
+  "territory_name",
+  "alert_type",
+  "area_alert_ha",
+  "g__type",
+  "g__coordinates",
+];
 
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
@@ -36,7 +56,12 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, metadata } = (await fetchData(table, limit)) as {
+    const { mainData, metadata } = (await fetchData(table, {
+      limit,
+      mainColumns: ALERTS_MAIN_PROJECTION,
+      includeMetadata: true,
+      metadataColumns: ALERTS_METADATA_PROJECTION,
+    })) as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];
     };
@@ -66,8 +91,12 @@ export default defineEventHandler(async (event: H3Event) => {
     let mapeoData: FeatureCollection | null = null;
 
     if (mapeoTable && mapeoCategoryIds) {
-      // Fetch Mapeo data
-      const rawMapeoData = await fetchData(mapeoTable);
+      const mapeoMainColumns = await fetchTableSqlColumns(mapeoTable);
+      // Fetch Mapeo data with explicit projection.
+      const rawMapeoData = await fetchData(mapeoTable, {
+        mainColumns: mapeoMainColumns,
+        includeColumnsData: true,
+      });
 
       // Filter data to remove unwanted columns and substrings
       const filteredMapeoData = filterUnwantedKeys(

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -16,6 +16,7 @@ import {
 import { buildMinimalFeatureCollection } from "@/utils/geoUtils";
 import { validatePermissions } from "@/utils/accessControls";
 import { parseBasemaps } from "@/server/utils";
+import { buildRequiredAlertsProjection } from "@/server/utils/alertsProjection";
 import { parseAndValidateLimit } from "@/server/utils/dbHelpers";
 
 import type { H3Event } from "h3";
@@ -37,28 +38,14 @@ const ALERTS_MAIN_PROJECTION = [
   "g__coordinates",
 ];
 
-/**
- * Keeps preferred projection columns that exist on the target table.
- * Falls back to all available columns when none of the preferred columns exist.
- *
- * @param {string[]} preferredColumns - Columns this route wants to project.
- * @param {string[]} availableColumns - Columns available on the target table.
- * @returns {string[]} Safe projection columns to send to fetchData.
- */
-const resolveProjectedColumns = (
-  preferredColumns: string[],
-  availableColumns: string[],
-): string[] => {
-  const projectedColumns = preferredColumns.filter((columnName) =>
-    availableColumns.includes(columnName),
-  );
-
-  if (projectedColumns.length > 0) {
-    return projectedColumns;
-  }
-
-  return availableColumns;
-};
+const REQUIRED_ALERTS_MAIN_COLUMNS = [
+  "_id",
+  "alert_id",
+  "month_detec",
+  "year_detec",
+  "g__type",
+  "g__coordinates",
+];
 
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
@@ -80,9 +67,12 @@ export default defineEventHandler(async (event: H3Event) => {
     await validatePermissions(event, permission);
 
     const availableMainColumns = await fetchTableSqlColumns(table);
-    const alertsMainProjection = resolveProjectedColumns(
+    const alertsMainProjection = buildRequiredAlertsProjection(
+      table,
       ALERTS_MAIN_PROJECTION,
+      REQUIRED_ALERTS_MAIN_COLUMNS,
       availableMainColumns,
+      "Alerts dashboard datasets",
     );
     const availableMetadataColumns = await fetchTableSqlColumns(
       `${table}__metadata`,

--- a/server/api/[table]/data.ts
+++ b/server/api/[table]/data.ts
@@ -1,5 +1,9 @@
 import { parseAndValidateLimit } from "@/server/utils/dbHelpers";
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchTableSqlColumns,
+} from "@/server/database/dbOperations";
 import { validatePermissions } from "@/utils/accessControls";
 
 import type { H3Event } from "h3";
@@ -14,7 +18,12 @@ export default defineEventHandler(async (event: H3Event) => {
 
     await validatePermissions(event, permission);
 
-    const { mainData, columnsData } = await fetchData(table, limit);
+    const mainColumns = await fetchTableSqlColumns(table);
+    const { mainData, columnsData } = await fetchData(table, {
+      limit,
+      mainColumns,
+      includeColumnsData: true,
+    });
     return {
       data: mainData,
       columns: columnsData,

--- a/server/api/[table]/export.get.ts
+++ b/server/api/[table]/export.get.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchTableSqlColumns,
+} from "@/server/database/dbOperations";
 import {
   filterGeoData,
   filterToSelectedValues,
@@ -141,7 +145,11 @@ export default defineEventHandler(async (event: H3Event) => {
     const permission = tableConfig.ROUTE_LEVEL_PERMISSION ?? "member";
     await validatePermissions(event, permission);
 
-    const { mainData, columnsData } = await fetchData(table);
+    const mainColumns = await fetchTableSqlColumns(table);
+    const { mainData, columnsData } = await fetchData(table, {
+      mainColumns,
+      includeColumnsData: true,
+    });
 
     const recordIdParam = (query.recordId as string | undefined)?.trim() ?? "";
 

--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchTableSqlColumns,
+} from "@/server/database/dbOperations";
 import {
   filterDataByExtension,
   filterUnwantedKeys,
@@ -29,7 +33,30 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, columnsData } = await fetchData(table, limit);
+    const filterColumn = tableConfig.FRONT_END_FILTER_COLUMN;
+    const mediaColumn = tableConfig.MEDIA_COLUMN;
+    const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
+    const filterByColumn = tableConfig.FILTER_BY_COLUMN;
+
+    const projectedColumns = mediaColumn
+      ? Array.from(
+          new Set(
+            [
+              "_id",
+              filterColumn,
+              timestampColumn,
+              mediaColumn,
+              filterByColumn,
+            ].filter((column): column is string => Boolean(column)),
+          ),
+        )
+      : await fetchTableSqlColumns(table);
+
+    const { mainData, columnsData } = await fetchData(table, {
+      limit,
+      mainColumns: projectedColumns,
+      includeColumnsData: true,
+    });
 
     // Filter data to remove unwanted columns and substrings
     const filteredData = filterUnwantedKeys(
@@ -50,10 +77,6 @@ export default defineEventHandler(async (event: H3Event) => {
       allowedFileExtensions,
       tableConfig.MEDIA_COLUMN,
     );
-
-    const filterColumn = tableConfig.FRONT_END_FILTER_COLUMN;
-    const mediaColumn = tableConfig.MEDIA_COLUMN;
-    const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
 
     // Return minimal records: ID + columns needed for filtering and media display
     const minimalData = dataWithFilesOnly.map((entry) => {

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -46,17 +46,19 @@ export default defineEventHandler(async (event: H3Event) => {
       /(date|time|created|modified|updated)/i.test(column),
     );
     const mainColumns = Array.from(
-      new Set([
-        "_id",
-        "g__type",
-        "g__coordinates",
-        colorColumn,
-        iconColumn,
-        filterColumn,
-        timestampColumn,
-        filterByColumn,
-        ...dateLikeColumns,
-      ].filter((column): column is string => Boolean(column))),
+      new Set(
+        [
+          "_id",
+          "g__type",
+          "g__coordinates",
+          colorColumn,
+          iconColumn,
+          filterColumn,
+          timestampColumn,
+          filterByColumn,
+          ...dateLikeColumns,
+        ].filter((column): column is string => Boolean(column)),
+      ),
     );
     const { mainData } = await fetchData(table, {
       limit,

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchTableSqlColumns,
+} from "@/server/database/dbOperations";
 import {
   filterOutUnwantedValues,
   filterGeoData,
@@ -31,22 +35,43 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData } = await fetchData(table, limit);
+    const colorColumn = tableConfig.COLOR_COLUMN;
+    const iconColumn = tableConfig.ICON_COLUMN;
+    const filterColumn = tableConfig.FRONT_END_FILTER_COLUMN;
+    const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
+    const filterByColumn = tableConfig.FILTER_BY_COLUMN;
+
+    const tableSqlColumns = await fetchTableSqlColumns(table);
+    const dateLikeColumns = tableSqlColumns.filter((column) =>
+      /(date|time|created|modified|updated)/i.test(column),
+    );
+    const mainColumns = Array.from(
+      new Set([
+        "_id",
+        "g__type",
+        "g__coordinates",
+        colorColumn,
+        iconColumn,
+        filterColumn,
+        timestampColumn,
+        filterByColumn,
+        ...dateLikeColumns,
+      ].filter((column): column is string => Boolean(column))),
+    );
+    const { mainData } = await fetchData(table, {
+      limit,
+      mainColumns,
+    });
 
     // Filter data to remove unwanted values per chosen column
     const dataFilteredByValues = filterOutUnwantedValues(
       mainData,
-      tableConfig.FILTER_BY_COLUMN,
+      filterByColumn,
       tableConfig.FILTER_OUT_VALUES_FROM_COLUMN,
     );
 
     // Filter only data with valid geofields
     const filteredGeoData = filterGeoData(dataFilteredByValues);
-
-    const colorColumn = tableConfig.COLOR_COLUMN;
-    const iconColumn = tableConfig.ICON_COLUMN;
-    const filterColumn = tableConfig.FRONT_END_FILTER_COLUMN;
-    const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
 
     // Process geodata
     const includeProperties = [colorColumn, iconColumn, timestampColumn].filter(

--- a/server/api/[table]/statistics-export.get.ts
+++ b/server/api/[table]/statistics-export.get.ts
@@ -2,6 +2,7 @@ import {
   ALERTS_METADATA_PROJECTION,
   fetchData,
   fetchTableConfig,
+  fetchTableSqlColumns,
 } from "@/server/database/dbOperations";
 import { prepareAlertsStatistics } from "@/server/dataProcessing/dataTransformers";
 import { validatePermissions } from "@/utils/accessControls";
@@ -28,6 +29,29 @@ const ALERTS_MAIN_PROJECTION = [
   "area_alert_ha",
 ];
 
+/**
+ * Keeps preferred projection columns that exist on the target table.
+ * Falls back to all available columns when none of the preferred columns exist.
+ *
+ * @param {string[]} preferredColumns - Columns this route wants to project.
+ * @param {string[]} availableColumns - Columns available on the target table.
+ * @returns {string[]} Safe projection columns to send to fetchData.
+ */
+const resolveProjectedColumns = (
+  preferredColumns: string[],
+  availableColumns: string[],
+): string[] => {
+  const projectedColumns = preferredColumns.filter((columnName) =>
+    availableColumns.includes(columnName),
+  );
+
+  if (projectedColumns.length > 0) {
+    return projectedColumns;
+  }
+
+  return availableColumns;
+};
+
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
   const query = getQuery(event);
@@ -45,10 +69,22 @@ export default defineEventHandler(async (event: H3Event) => {
     const permission = tableConfig.ROUTE_LEVEL_PERMISSION ?? "member";
     await validatePermissions(event, permission);
 
+    const availableMainColumns = await fetchTableSqlColumns(table);
+    const alertsMainProjection = resolveProjectedColumns(
+      ALERTS_MAIN_PROJECTION,
+      availableMainColumns,
+    );
+    const availableMetadataColumns = await fetchTableSqlColumns(
+      `${table}__metadata`,
+    );
+    const alertsMetadataProjection = ALERTS_METADATA_PROJECTION.filter(
+      (columnName) => availableMetadataColumns.includes(columnName),
+    );
+
     const { mainData, metadata } = (await fetchData(table, {
-      mainColumns: ALERTS_MAIN_PROJECTION,
-      includeMetadata: true,
-      metadataColumns: ALERTS_METADATA_PROJECTION,
+      mainColumns: alertsMainProjection,
+      includeMetadata: alertsMetadataProjection.length > 0,
+      metadataColumns: alertsMetadataProjection,
     })) as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[] | null;

--- a/server/api/[table]/statistics-export.get.ts
+++ b/server/api/[table]/statistics-export.get.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  ALERTS_METADATA_PROJECTION,
+  fetchData,
+  fetchTableConfig,
+} from "@/server/database/dbOperations";
 import { prepareAlertsStatistics } from "@/server/dataProcessing/dataTransformers";
 import { validatePermissions } from "@/utils/accessControls";
 import {
@@ -12,6 +16,17 @@ import type { AlertsMetadata, DataEntry } from "@/types";
 
 const SUPPORTED_FORMATS = ["csv"] as const;
 type ExportFormat = (typeof SUPPORTED_FORMATS)[number];
+const ALERTS_MAIN_PROJECTION = [
+  "_id",
+  "month_detec",
+  "year_detec",
+  "day_detec",
+  "date_end_t1",
+  "data_source",
+  "territory_name",
+  "alert_type",
+  "area_alert_ha",
+];
 
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
@@ -30,7 +45,11 @@ export default defineEventHandler(async (event: H3Event) => {
     const permission = tableConfig.ROUTE_LEVEL_PERMISSION ?? "member";
     await validatePermissions(event, permission);
 
-    const { mainData, metadata } = (await fetchData(table)) as {
+    const { mainData, metadata } = (await fetchData(table, {
+      mainColumns: ALERTS_MAIN_PROJECTION,
+      includeMetadata: true,
+      metadataColumns: ALERTS_METADATA_PROJECTION,
+    })) as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[] | null;
     };

--- a/server/api/[table]/statistics-export.get.ts
+++ b/server/api/[table]/statistics-export.get.ts
@@ -5,6 +5,7 @@ import {
   fetchTableSqlColumns,
 } from "@/server/database/dbOperations";
 import { prepareAlertsStatistics } from "@/server/dataProcessing/dataTransformers";
+import { buildRequiredAlertsProjection } from "@/server/utils/alertsProjection";
 import { validatePermissions } from "@/utils/accessControls";
 import {
   buildStatisticsMonthlyRows,
@@ -29,28 +30,14 @@ const ALERTS_MAIN_PROJECTION = [
   "area_alert_ha",
 ];
 
-/**
- * Keeps preferred projection columns that exist on the target table.
- * Falls back to all available columns when none of the preferred columns exist.
- *
- * @param {string[]} preferredColumns - Columns this route wants to project.
- * @param {string[]} availableColumns - Columns available on the target table.
- * @returns {string[]} Safe projection columns to send to fetchData.
- */
-const resolveProjectedColumns = (
-  preferredColumns: string[],
-  availableColumns: string[],
-): string[] => {
-  const projectedColumns = preferredColumns.filter((columnName) =>
-    availableColumns.includes(columnName),
-  );
-
-  if (projectedColumns.length > 0) {
-    return projectedColumns;
-  }
-
-  return availableColumns;
-};
+const REQUIRED_ALERTS_STATISTICS_COLUMNS = [
+  "month_detec",
+  "year_detec",
+  "data_source",
+  "territory_name",
+  "alert_type",
+  "area_alert_ha",
+];
 
 export default defineEventHandler(async (event: H3Event) => {
   const { table } = event.context.params as { table: string };
@@ -70,9 +57,12 @@ export default defineEventHandler(async (event: H3Event) => {
     await validatePermissions(event, permission);
 
     const availableMainColumns = await fetchTableSqlColumns(table);
-    const alertsMainProjection = resolveProjectedColumns(
+    const alertsMainProjection = buildRequiredAlertsProjection(
+      table,
       ALERTS_MAIN_PROJECTION,
+      REQUIRED_ALERTS_STATISTICS_COLUMNS,
       availableMainColumns,
+      "Alerts statistics exports",
     );
     const availableMetadataColumns = await fetchTableSqlColumns(
       `${table}__metadata`,

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -178,7 +178,9 @@ export const ALERTS_METADATA_PROJECTION = [
  * @param {string} table - Base table name.
  * @returns {Promise<string[]>} Ordered list of available SQL column names.
  */
-export const fetchTableSqlColumns = async (table: string): Promise<string[]> => {
+export const fetchTableSqlColumns = async (
+  table: string,
+): Promise<string[]> => {
   const cleanTableName = table.replace(/"/g, "");
   const columnsTable = `"${cleanTableName}__columns"`;
 

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -52,6 +52,12 @@ const ensureViewConfigTableExists = async (): Promise<void> => {
   }
 };
 
+/**
+ * Checks whether a given table exists in the warehouse schema.
+ *
+ * @param {string | undefined} table - Table name to verify.
+ * @returns {Promise<boolean>} True when the table exists, otherwise false.
+ */
 const checkTableExists = async (
   table: string | undefined,
 ): Promise<boolean> => {
@@ -69,17 +75,68 @@ const checkTableExists = async (
   }
 };
 
+const VALID_COLUMN_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Normalizes and validates a projection list before a SQL read is built.
+ * Trims names, removes duplicates, rejects empty lists, and enforces safe
+ * SQL identifier shape for all projected columns.
+ *
+ * @param {string[]} columns - Candidate column names for projection.
+ * @param {string} contextLabel - Label used in validation error messages.
+ * @returns {string[]} Sanitized and deduplicated projection columns.
+ */
+const normalizeProjectionColumns = (
+  columns: string[],
+  contextLabel: string,
+): string[] => {
+  const normalized = Array.from(
+    new Set(columns.map((column) => column.trim()).filter(Boolean)),
+  );
+
+  if (normalized.length === 0) {
+    throw new Error(`Projection for ${contextLabel} cannot be empty`);
+  }
+
+  for (const column of normalized) {
+    if (!VALID_COLUMN_NAME.test(column)) {
+      throw new Error(
+        `Invalid column "${column}" in projection for ${contextLabel}`,
+      );
+    }
+  }
+
+  return normalized;
+};
+
+/**
+ * Fetches rows from a table using an explicit column projection.
+ *
+ * @param {string | undefined} table - Source table name.
+ * @param {string[]} projectionColumns - Columns to include in SELECT.
+ * @param {number} [limit] - Optional row limit for the query.
+ * @returns {Promise<unknown[]>} Result rows, or an empty array when unavailable.
+ */
 const fetchDataFromTable = async (
   table: string | undefined,
+  projectionColumns: string[],
   limit?: number,
 ): Promise<unknown[]> => {
   if (!table) return [];
 
   try {
     const cleanTableName = table.replace(/"/g, "");
+    const normalizedProjection = normalizeProjectionColumns(
+      projectionColumns,
+      cleanTableName,
+    );
+    const selectedColumns = sql.join(
+      normalizedProjection.map((column) => sql.identifier(column)),
+      sql`, `,
+    );
     const query = limit
-      ? sql`SELECT * FROM ${sql.identifier(cleanTableName)} LIMIT ${limit}`
-      : sql`SELECT * FROM ${sql.identifier(cleanTableName)}`;
+      ? sql`SELECT ${selectedColumns} FROM ${sql.identifier(cleanTableName)} LIMIT ${limit}`
+      : sql`SELECT ${selectedColumns} FROM ${sql.identifier(cleanTableName)}`;
     const result = await warehouseDb.execute(query);
     return result || [];
   } catch (error) {
@@ -88,40 +145,141 @@ const fetchDataFromTable = async (
   }
 };
 
+export type FetchDataOptions = {
+  mainColumns: string[];
+  limit?: number;
+  includeColumnsData?: boolean;
+  includeMetadata?: boolean;
+  columnsTableColumns?: string[];
+  metadataColumns?: string[];
+};
+
+export const DEFAULT_COLUMNS_TABLE_PROJECTION = [
+  "original_column",
+  "sql_column",
+];
+
+export const ALERTS_METADATA_PROJECTION = [
+  "data_source",
+  "type_alert",
+  "month",
+  "year",
+  "day",
+  "total_alerts",
+  "description_alerts",
+  "territory",
+];
+
+/**
+ * Resolves SQL column names for a table without using wildcard reads.
+ * Prefers `<table>__columns.sql_column` when available, and falls back to
+ * `information_schema.columns` in ordinal order.
+ *
+ * @param {string} table - Base table name.
+ * @returns {Promise<string[]>} Ordered list of available SQL column names.
+ */
+export const fetchTableSqlColumns = async (table: string): Promise<string[]> => {
+  const cleanTableName = table.replace(/"/g, "");
+  const columnsTable = `"${cleanTableName}__columns"`;
+
+  if (await checkTableExists(columnsTable)) {
+    const columns = (await fetchDataFromTable(columnsTable, [
+      "sql_column",
+    ])) as Array<{ sql_column?: unknown }>;
+    const columnNames = columns
+      .map((entry) => entry.sql_column)
+      .filter((value): value is string => typeof value === "string");
+
+    if (columnNames.length > 0) {
+      return Array.from(new Set(columnNames));
+    }
+  }
+
+  const schemaColumns = await warehouseDb.execute(sql`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = ${cleanTableName}
+    ORDER BY ordinal_position
+  `);
+
+  return Array.from(
+    new Set(
+      schemaColumns
+        .map(
+          (row: unknown) =>
+            (row as Record<string, unknown>).column_name as string | undefined,
+        )
+        .filter((column): column is string => Boolean(column)),
+    ),
+  );
+};
+
+/**
+ * Fetches projected dataset rows and optional side tables for API routes.
+ * Main-table projection is mandatory, while `__columns` and `__metadata`
+ * reads are opt-in and require explicit projections.
+ *
+ * @param {string | undefined} table - Base table name.
+ * @param {FetchDataOptions} options - Projection and inclusion settings.
+ * @returns {Promise<{ mainData: DataEntry[]; columnsData: ColumnEntry[] | null; metadata: unknown[] | null }>} Projected data payloads.
+ */
 export const fetchData = async (
   table: string | undefined,
-  limit?: number,
+  options: FetchDataOptions,
 ): Promise<{
   mainData: DataEntry[];
   columnsData: ColumnEntry[] | null;
   metadata: unknown[] | null;
 }> => {
+  // Performance rule: projection must be pushed down to DB (never SELECT *).
+  const mainProjection = normalizeProjectionColumns(
+    options.mainColumns,
+    `${table ?? "unknown table"} main table`,
+  );
   const resolvedLimit =
-    limit ?? Number(useRuntimeConfig().public.rowLimit as number);
+    options.limit ?? Number(useRuntimeConfig().public.rowLimit as number);
 
   console.log("Fetching data from", table, "...");
   const mainDataExists = await checkTableExists(table);
   let mainData: DataEntry[] = [];
   if (mainDataExists) {
-    mainData = (await fetchDataFromTable(table, resolvedLimit)) as DataEntry[];
+    mainData = (await fetchDataFromTable(
+      table,
+      mainProjection,
+      resolvedLimit,
+    )) as DataEntry[];
   } else {
     throw new Error("Main table does not exist");
   }
 
-  // Fetch mapping columns
-  const columnsTable = `"${table}__columns"`;
-  const columnsTableExists = await checkTableExists(columnsTable);
   let columnsData = null;
-  if (columnsTableExists) {
-    columnsData = (await fetchDataFromTable(columnsTable)) as ColumnEntry[];
+  if (options.includeColumnsData) {
+    const columnsProjection = normalizeProjectionColumns(
+      options.columnsTableColumns ?? [...DEFAULT_COLUMNS_TABLE_PROJECTION],
+      `${table ?? "unknown table"}__columns table`,
+    );
+    const columnsTable = `"${table}__columns"`;
+    const columnsTableExists = await checkTableExists(columnsTable);
+    if (columnsTableExists) {
+      columnsData = (await fetchDataFromTable(
+        columnsTable,
+        columnsProjection,
+      )) as ColumnEntry[];
+    }
   }
 
-  // Fetch metadata
-  const metadataTable = `"${table}__metadata"`;
-  const metadataTableExists = await checkTableExists(metadataTable);
   let metadata = null;
-  if (metadataTableExists) {
-    metadata = await fetchDataFromTable(metadataTable);
+  if (options.includeMetadata) {
+    const metadataProjection = normalizeProjectionColumns(
+      options.metadataColumns ?? [],
+      `${table ?? "unknown table"}__metadata table`,
+    );
+    const metadataTable = `"${table}__metadata"`;
+    const metadataTableExists = await checkTableExists(metadataTable);
+    if (metadataTableExists) {
+      metadata = await fetchDataFromTable(metadataTable, metadataProjection);
+    }
   }
 
   console.log("Successfully fetched data from", table, "!");

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import type {
   ColumnEntry,
   DataEntry,
+  FetchDataOptions,
   RouteLevelPermission,
   Views,
   ViewConfig,
@@ -143,15 +144,6 @@ const fetchDataFromTable = async (
     console.error("Error fetching data from table:", error);
     return [];
   }
-};
-
-export type FetchDataOptions = {
-  mainColumns: string[];
-  limit?: number;
-  includeColumnsData?: boolean;
-  includeMetadata?: boolean;
-  columnsTableColumns?: string[];
-  metadataColumns?: string[];
 };
 
 export const DEFAULT_COLUMNS_TABLE_PROJECTION = [

--- a/server/utils/alertsProjection.ts
+++ b/server/utils/alertsProjection.ts
@@ -1,0 +1,32 @@
+/**
+ * Builds an alerts projection from preferred columns and enforces required fields.
+ *
+ * @param {string} table - Alerts table name.
+ * @param {string[]} preferredColumns - Columns to project when available.
+ * @param {string[]} requiredColumns - Columns that must exist for this dataset shape.
+ * @param {string[]} availableColumns - Columns available on the target table.
+ * @param {string} requirementLabel - Human-readable label used in error messaging.
+ * @returns {string[]} Preferred columns that exist on the target table.
+ */
+export const buildRequiredAlertsProjection = (
+  table: string,
+  preferredColumns: string[],
+  requiredColumns: string[],
+  availableColumns: string[],
+  requirementLabel: string,
+): string[] => {
+  const missingRequiredColumns = requiredColumns.filter(
+    (columnName) => !availableColumns.includes(columnName),
+  );
+
+  if (missingRequiredColumns.length > 0) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: `${requirementLabel} require columns ${missingRequiredColumns.join(", ")} in table "${table}".`,
+    });
+  }
+
+  return preferredColumns.filter((columnName) =>
+    availableColumns.includes(columnName),
+  );
+};

--- a/tests/unit/server/exportEndpoint.test.ts
+++ b/tests/unit/server/exportEndpoint.test.ts
@@ -328,9 +328,7 @@ describe("GET api/[table]/export", () => {
 
       await expect(
         mockFetchData("nonexistent", { mainColumns: ["_id"] }),
-      ).rejects.toThrow(
-        "Main table does not exist",
-      );
+      ).rejects.toThrow("Main table does not exist");
     });
 
     it("preserves raw untransformed values in CSV output", async () => {

--- a/tests/unit/server/exportEndpoint.test.ts
+++ b/tests/unit/server/exportEndpoint.test.ts
@@ -9,7 +9,10 @@ const mockFetchData = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
   fetchConfig: () => mockFetchConfig(),
-  fetchData: (table: string) => mockFetchData(table),
+  fetchData: (
+    table: string,
+    options: { mainColumns: string[]; includeColumnsData?: boolean },
+  ) => mockFetchData(table, options),
 }));
 
 vi.mock("@/utils/accessControls", () => ({
@@ -65,7 +68,10 @@ describe("GET api/[table]/export", () => {
 
   describe("CSV format", () => {
     it("builds correct CSV with headers from column metadata", async () => {
-      const { mainData, columnsData } = await mockFetchData("test_table");
+      const { mainData, columnsData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+        includeColumnsData: true,
+      });
 
       const headers = columnsData.map(
         (column: { sql_column: string }) => column.sql_column,
@@ -99,7 +105,10 @@ describe("GET api/[table]/export", () => {
         metadata: null,
       });
 
-      const { mainData, columnsData } = await mockFetchData("test_table");
+      const { mainData, columnsData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "note"],
+        includeColumnsData: true,
+      });
 
       const headers = columnsData.map(
         (column: { sql_column: string }) => column.sql_column,
@@ -120,7 +129,9 @@ describe("GET api/[table]/export", () => {
 
   describe("GeoJSON format", () => {
     it("builds valid FeatureCollection from records with coordinates", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
 
       const features = mainData
         .filter(
@@ -154,7 +165,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("excludes records without valid coordinates", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
 
       const features = mainData.filter(
         (entry: Record<string, unknown>) =>
@@ -171,7 +184,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("excludes g__ prefixed keys from feature properties", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
 
       const entry = mainData[0];
       const properties: Record<string, unknown> = {};
@@ -213,7 +228,9 @@ describe("GET api/[table]/export", () => {
     };
 
     it("produces valid KML with root element and namespace", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
       const geojson = buildGeoJsonFromData(mainData);
       const kml: string = tokml(geojson);
 
@@ -224,7 +241,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("wraps features in a Document with Placemark elements", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
       const geojson = buildGeoJsonFromData(mainData);
       const kml: string = tokml(geojson);
 
@@ -236,7 +255,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("includes Point coordinates in lon,lat order", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
       const geojson = buildGeoJsonFromData(mainData);
       const kml: string = tokml(geojson);
 
@@ -247,7 +268,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("embeds feature properties as ExtendedData", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
       const geojson = buildGeoJsonFromData(mainData);
       const kml: string = tokml(geojson);
 
@@ -261,7 +284,9 @@ describe("GET api/[table]/export", () => {
     });
 
     it("excludes records without coordinates", async () => {
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: ["_id", "name", "category", "g__type", "g__coordinates"],
+      });
       const geojson = buildGeoJsonFromData(mainData);
       const kml: string = tokml(geojson);
 
@@ -301,7 +326,9 @@ describe("GET api/[table]/export", () => {
     it("propagates error when table does not exist", async () => {
       mockFetchData.mockRejectedValue(new Error("Main table does not exist"));
 
-      await expect(mockFetchData("nonexistent")).rejects.toThrow(
+      await expect(
+        mockFetchData("nonexistent", { mainColumns: ["_id"] }),
+      ).rejects.toThrow(
         "Main table does not exist",
       );
     });
@@ -327,7 +354,15 @@ describe("GET api/[table]/export", () => {
         metadata: null,
       });
 
-      const { mainData } = await mockFetchData("test_table");
+      const { mainData } = await mockFetchData("test_table", {
+        mainColumns: [
+          "_id",
+          "p__categoryid",
+          "g__type",
+          "g__coordinates",
+          "p__photos",
+        ],
+      });
 
       expect(mainData[0].p__categoryid).toBe("threat");
       expect(mainData[0].g__type).toBe("Point");

--- a/tests/unit/server/fetchDataProjection.test.ts
+++ b/tests/unit/server/fetchDataProjection.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const FETCH_DATA_ROUTE_FILES = [
+  "server/api/[table]/alerts.ts",
+  "server/api/[table]/data.ts",
+  "server/api/[table]/export.get.ts",
+  "server/api/[table]/gallery.ts",
+  "server/api/[table]/map.ts",
+  "server/api/[table]/statistics-export.get.ts",
+];
+
+describe("fetchData projection guardrails", () => {
+  it("ensures every route-level fetchData call defines mainColumns", async () => {
+    for (const relativePath of FETCH_DATA_ROUTE_FILES) {
+      const fullPath = resolve(process.cwd(), relativePath);
+      const fileContents = await readFile(fullPath, "utf8");
+
+      const fetchDataCallCount = (fileContents.match(/fetchData\s*\(/g) ?? [])
+        .length;
+      const mainColumnsCount = (
+        fileContents.match(/mainColumns\s*:|mainColumns\s*,/g) ?? []
+      ).length;
+
+      expect(mainColumnsCount).toBeGreaterThanOrEqual(fetchDataCallCount);
+    }
+  });
+});

--- a/tests/unit/server/rowLimit.test.ts
+++ b/tests/unit/server/rowLimit.test.ts
@@ -9,7 +9,8 @@ const mockFetchData = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
   fetchConfig: () => mockFetchConfig(),
-  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+  fetchData: (table: string, options: { limit?: number; mainColumns: string[] }) =>
+    mockFetchData(table, options),
 }));
 
 vi.mock("@/utils/accessControls", () => ({
@@ -119,9 +120,10 @@ describe("dataset endpoints pass limit to fetchData", () => {
       metadata: null,
     });
 
-    const { mainData } = await mockFetchData("test_table", limit);
+    const options = { limit, mainColumns: ["_id", "name"] };
+    const { mainData } = await mockFetchData("test_table", options);
 
-    expect(mockFetchData).toHaveBeenCalledWith("test_table", limit);
+    expect(mockFetchData).toHaveBeenCalledWith("test_table", options);
     expect(mainData.length >= limit).toBe(true);
   });
 
@@ -138,9 +140,10 @@ describe("dataset endpoints pass limit to fetchData", () => {
       metadata: null,
     });
 
-    const { mainData } = await mockFetchData("test_table", limit);
+    const options = { limit, mainColumns: ["_id", "name"] };
+    const { mainData } = await mockFetchData("test_table", options);
 
-    expect(mockFetchData).toHaveBeenCalledWith("test_table", limit);
+    expect(mockFetchData).toHaveBeenCalledWith("test_table", options);
     expect(mainData.length >= limit).toBe(false);
   });
 });

--- a/tests/unit/server/rowLimit.test.ts
+++ b/tests/unit/server/rowLimit.test.ts
@@ -9,8 +9,10 @@ const mockFetchData = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
   fetchConfig: () => mockFetchConfig(),
-  fetchData: (table: string, options: { limit?: number; mainColumns: string[] }) =>
-    mockFetchData(table, options),
+  fetchData: (
+    table: string,
+    options: { limit?: number; mainColumns: string[] },
+  ) => mockFetchData(table, options),
 }));
 
 vi.mock("@/utils/accessControls", () => ({

--- a/types/index.ts
+++ b/types/index.ts
@@ -86,6 +86,15 @@ export type DataEntry = Record<string, string> & {
   normalizedId?: number;
 };
 
+export type FetchDataOptions = {
+  mainColumns: string[];
+  limit?: number;
+  includeColumnsData?: boolean;
+  includeMetadata?: boolean;
+  columnsTableColumns?: string[];
+  metadataColumns?: string[];
+};
+
 export type Dataset = Array<DataEntry>;
 
 export type FilterValues = Array<string>;


### PR DESCRIPTION
## Goal

Enforces database-level projection for all `fetchData` usage so server reads no longer depend on broad row loads (`SELECT *`) followed by in-memory trimming, and add guardrails to prevent regressions. Closes #393 

## Screenshots

N/A (server-side performance and API behavior changes).

## What I changed and why

- Refactored `fetchData` to require an explicit options object with mandatory `mainColumns`, removing implicit unrestricted reads
- Projection columns are now validated/sanitized, and side tables (`__columns`, `__metadata`) are only read when explicitly requested with explicit projections
- Projection is pushed down to SQL for all route-level consumers, preventing accidental wildcard access patterns that could scale memory use with table width
- Migrated all server `fetchData` callsites (`data`, `map`, `gallery`, `alerts`, `statistics-export`, `export`) to pass explicit projections based on each endpoint's needs
- Added schema-aware column resolution at callsites where table variants differ
- Added guardrail tests to enforce `mainColumns` usage in route fetches, and updated existing unit tests for the new `fetchData` API shape
- Fixed alerts regressions during rollout by making alerts/statistics projection selection schema-aware while preserving the explicit projection path (no wildcard queries)

## What I'm not doing here

- Not introducing `SELECT *` fallback behavior.
- Not redesigning endpoint response contracts or frontend rendering logic.
## LLM use disclosure
Osa and Codex 5.3