### PR TITLE
193.4: Integrate primary & secondary dataset params in alerts dashboard client

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -102,11 +102,11 @@ const props = defineProps<{
   mapbox3d: boolean;
   mapbox3dTerrainExaggeration: number;
   mapeoData: FeatureCollection | null;
-  mapeoTable?: string;
+  primaryDataset: string;
+  secondaryDataset?: string | null;
   mediaBasePath: string | undefined;
   mediaBasePathAlerts: string | undefined;
   planetApiKey: string | undefined;
-  table: string;
 }>();
 
 const localAlertsData = ref<Feature | AlertsData>(props.alertsData);
@@ -167,7 +167,8 @@ const {
   route,
   router,
   toRef(props, "mapLegendLayerIds"),
-  toRef(props, "mapeoTable"),
+  toRef(props, "primaryDataset"),
+  toRef(props, "secondaryDataset"),
 );
 
 // Use feature selection composable
@@ -206,7 +207,7 @@ watch(
     }
     if (!feature) return;
 
-    const isMapeoFeature = isMapeo.value && props.mapeoTable;
+    const isMapeoFeature = isMapeo.value && !!props.secondaryDataset;
     const isMinimalAlert = !isMapeo.value && feature.alertID && feature._id;
 
     if (!isMapeoFeature && !isMinimalAlert) return;
@@ -214,7 +215,9 @@ watch(
     const recordId = feature._id || feature.id;
     if (!recordId) return;
 
-    const fetchTable = isMapeoFeature ? props.mapeoTable! : props.table;
+    const fetchTable = isMapeoFeature
+      ? props.secondaryDataset!
+      : props.primaryDataset;
     const minimalFeature = { ...feature };
     selectedFeature.value = null;
     selectedFeatureLoading.value = true;
@@ -233,7 +236,7 @@ watch(
       );
     } else {
       displayRecord = fullRecord
-        ? transformAlertEntry(fullRecord, props.table)
+        ? transformAlertEntry(fullRecord, props.primaryDataset)
         : minimalFeature;
       imageUrl.value = [];
       if (displayRecord.t0_url)
@@ -1710,7 +1713,9 @@ onBeforeUnmount(() => {
       :allowed-file-extensions="allowedFileExtensions"
       :calculate-hectares="calculateHectares"
       :date-options="dateOptions"
-      :export-table-name="isMapeo ? mapeoTable : table"
+      :export-table-name="
+        isMapeo && secondaryDataset ? secondaryDataset : primaryDataset
+      "
       :feature="selectedFeature"
       :feature-loading="selectedFeatureLoading"
       :feature-geojson="localAlertsData"

--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -106,12 +106,7 @@ export const useIncidents = (
   const SOURCE_ID_KEYS = ["alertID", "_id", "source_id", "sourceId"] as const;
 
   const getCurrentAlertsTable = (): string | undefined => {
-    if (primaryDatasetRef?.value) {
-      return primaryDatasetRef.value;
-    }
-    const tableRaw = route.params.tablename;
-    if (!tableRaw) return undefined;
-    return Array.isArray(tableRaw) ? tableRaw.join("/") : String(tableRaw);
+    return primaryDatasetRef?.value;
   };
 
   /**

--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -40,7 +40,8 @@ export const useIncidents = (
   route: RouteLocationNormalizedLoaded,
   router: Router,
   mapLegendLayerIds?: Ref<string | undefined>,
-  mapeoTableRef?: Ref<string | undefined>,
+  primaryDatasetRef?: Ref<string | undefined>,
+  secondaryDatasetRef?: Ref<string | null | undefined>,
 ) => {
   // Incidents state management
   const incidents = ref<AnnotatedCollection[]>([]);
@@ -104,12 +105,10 @@ export const useIncidents = (
 
   const SOURCE_ID_KEYS = ["alertID", "_id", "source_id", "sourceId"] as const;
 
-  /**
-   * Returns current alerts table name from route params.
-   *
-   * @returns Alerts table slug string or undefined.
-   */
   const getCurrentAlertsTable = (): string | undefined => {
+    if (primaryDatasetRef?.value) {
+      return primaryDatasetRef.value;
+    }
     const tableRaw = route.params.tablename;
     if (!tableRaw) return undefined;
     return Array.isArray(tableRaw) ? tableRaw.join("/") : String(tableRaw);
@@ -120,7 +119,7 @@ export const useIncidents = (
    * is the warehouse table name (often the view’s MAPEO_TABLE, or `mapeo_data`)
    */
   const savedEntryIsMapeo = (entry: CollectionEntry): boolean => {
-    const configuredMapeoTable = mapeoTableRef?.value;
+    const configuredMapeoTable = secondaryDatasetRef?.value;
     return (
       entry.source_table === "mapeo_data" ||
       (!!configuredMapeoTable && entry.source_table === configuredMapeoTable)
@@ -1091,7 +1090,7 @@ const SOURCE_ID_KEYS = ['alertID', '_id', 'source_id', 'sourceId'] as const;
       sourceTable = (tableName as string) || "";
       featureType = "alert";
     } else if (layerId.startsWith("mapeo-data")) {
-      sourceTable = mapeoTableRef?.value ?? "";
+      sourceTable = secondaryDatasetRef?.value ?? "";
       featureType = "mapeo";
     } else if (isAdditionalSelectableLayer(layerId)) {
       sourceTable = (tableName as string) || "";

--- a/pages/alerts/[tablename].vue
+++ b/pages/alerts/[tablename].vue
@@ -33,7 +33,8 @@ const mapboxZoom = ref(0);
 const mapbox3d = ref(false);
 const mapbox3dTerrainExaggeration = ref(0);
 const mapeoData = ref();
-const mapeoTable = ref<string>();
+const primaryDataset = ref("");
+const secondaryDataset = ref<string | null>(null);
 const mediaBasePath = ref();
 const mediaBasePathAlerts = ref();
 const planetApiKey = ref();
@@ -62,8 +63,9 @@ if (data.value && !error.value) {
   mapboxZoom.value = data.value.mapboxZoom;
   mapbox3d.value = data.value.mapbox3d;
   mapbox3dTerrainExaggeration.value = data.value.mapbox3dTerrainExaggeration;
+  primaryDataset.value = data.value.primary_dataset || "";
+  secondaryDataset.value = data.value.secondary_dataset;
   mapeoData.value = data.value.mapeoData;
-  mapeoTable.value = data.value.mapeoTable;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaBasePathAlerts.value = data.value.mediaBasePathAlerts;
   planetApiKey.value = data.value.planetApiKey;
@@ -116,11 +118,11 @@ useHead({
         :mapbox3d="mapbox3d"
         :mapbox3d-terrain-exaggeration="mapbox3dTerrainExaggeration"
         :mapeo-data="mapeoData"
-        :mapeo-table="mapeoTable"
+        :primary-dataset="primaryDataset"
+        :secondary-dataset="secondaryDataset"
         :media-base-path="mediaBasePath"
         :media-base-path-alerts="mediaBasePathAlerts"
         :planet-api-key="planetApiKey"
-        :table="table"
       />
     </ClientOnly>
   </div>

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,6 +1,6 @@
 import {
   fetchViewDatasets,
-  fetchData,
+  fetchViewDatasetData,
   fetchTableConfig,
 } from "@/server/database/dbOperations";
 import murmurhash from "murmurhash";
@@ -45,7 +45,15 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, metadata } = (await fetchData(primaryDataset, limit)) as {
+    const { primaryData, secondaryData } = await fetchViewDatasetData(
+      primaryDataset,
+      {
+        secondaryDataset,
+        limit,
+      },
+    );
+
+    const { mainData, metadata } = primaryData as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];
     };
@@ -74,9 +82,8 @@ export default defineEventHandler(async (event: H3Event) => {
 
     let mapeoData: FeatureCollection | null = null;
 
-    if (mapeoTable && mapeoCategoryIds) {
-      // Fetch Mapeo data
-      const rawMapeoData = await fetchData(mapeoTable);
+    if (mapeoTable && mapeoCategoryIds && secondaryData) {
+      const rawMapeoData = secondaryData;
 
       // Filter data to remove unwanted columns and substrings
       const filteredMapeoData = filterUnwantedKeys(

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import type {
   ColumnEntry,
   DataEntry,
+  FetchedDatasetData,
   RouteLevelPermission,
   ViewDatasets,
   Views,
@@ -224,6 +225,43 @@ export const fetchData = async (
   console.log("Successfully fetched data from", table, "!");
 
   return { mainData, columnsData, metadata };
+};
+
+/**
+ * Fetches primary and optional secondary dataset payloads in one DB-layer call.
+ *
+ * Endpoints that render views across multiple datasets should call this helper
+ * instead of making separate `fetchData()` calls per dataset. When
+ * `secondaryDataset` is provided, both datasets are fetched concurrently and
+ * returned in a single structured response.
+ *
+ * @param {string} primaryDataset - Required primary warehouse table name.
+ * @param {{ secondaryDataset?: string | null; limit?: number }} [options] - Optional secondary dataset and primary limit.
+ * @returns {Promise<{ primaryData: FetchedDatasetData; secondaryData: FetchedDatasetData | null }>} Fetched dataset payloads.
+ */
+export const fetchViewDatasetData = async (
+  primaryDataset: string,
+  options?: {
+    secondaryDataset?: string | null;
+    limit?: number;
+  },
+): Promise<{
+  primaryData: FetchedDatasetData;
+  secondaryData: FetchedDatasetData | null;
+}> => {
+  const primaryPromise = fetchData(primaryDataset, options?.limit);
+  if (!options?.secondaryDataset) {
+    const primaryData = (await primaryPromise) as FetchedDatasetData;
+    return { primaryData, secondaryData: null };
+  }
+
+  const secondaryPromise = fetchData(options.secondaryDataset);
+  const [primaryData, secondaryData] = (await Promise.all([
+    primaryPromise,
+    secondaryPromise,
+  ])) as [FetchedDatasetData, FetchedDatasetData];
+
+  return { primaryData, secondaryData };
 };
 
 /**

--- a/tests/unit/components/AlertsDashboard.test.ts
+++ b/tests/unit/components/AlertsDashboard.test.ts
@@ -67,10 +67,11 @@ const baseProps: InstanceType<typeof AlertsDashboard>["$props"] = {
   mapbox3d: false,
   mapbox3dTerrainExaggeration: 1.5,
   mapeoData: null,
+  primaryDataset: "test_alerts",
+  secondaryDataset: null,
   mediaBasePath: "",
   mediaBasePathAlerts: "",
   planetApiKey: "",
-  table: "test_alerts",
 };
 
 // Mock Nuxt composables - needs to be before component import

--- a/tests/unit/server/alertsEndpointDatasets.test.ts
+++ b/tests/unit/server/alertsEndpointDatasets.test.ts
@@ -2,14 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchViewDatasets = vi.fn();
 const mockFetchTableConfig = vi.fn();
-const mockFetchData = vi.fn();
+const mockFetchViewDatasetData = vi.fn();
 const mockValidatePermissions = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
   fetchViewDatasets: (table: string, viewType: string) =>
     mockFetchViewDatasets(table, viewType),
   fetchTableConfig: (table: string) => mockFetchTableConfig(table),
-  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+  fetchViewDatasetData: (
+    primaryDataset: string,
+    options?: { secondaryDataset?: string | null; limit?: number },
+  ) => mockFetchViewDatasetData(primaryDataset, options),
 }));
 
 vi.mock("@/utils/accessControls", () => ({
@@ -76,10 +79,13 @@ describe("alerts endpoint dataset config", () => {
       PLANET_API_KEY: "",
     });
 
-    mockFetchData.mockResolvedValue({
-      mainData: [{ _id: "1", alertID: "a1" }],
-      columnsData: null,
-      metadata: [],
+    mockFetchViewDatasetData.mockResolvedValue({
+      primaryData: {
+        mainData: [{ _id: "1", alertID: "a1" }],
+        columnsData: null,
+        metadata: [],
+      },
+      secondaryData: null,
     });
   });
 
@@ -98,8 +104,14 @@ describe("alerts endpoint dataset config", () => {
       "alerts_confidential",
       "alerts",
     );
-    expect(mockFetchData).toHaveBeenCalledWith("alerts_confidential", 100);
-    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(mockFetchViewDatasetData).toHaveBeenCalledWith(
+      "alerts_confidential",
+      {
+        secondaryDataset: null,
+        limit: 100,
+      },
+    );
+    expect(mockFetchViewDatasetData).toHaveBeenCalledTimes(1);
     expect(response["primary_dataset"]).toBe("alerts_confidential");
     expect(response["secondary_dataset"]).toBeNull();
   });

--- a/types/index.ts
+++ b/types/index.ts
@@ -93,6 +93,12 @@ export type DataEntry = Record<string, string> & {
   normalizedId?: number;
 };
 
+export type FetchedDatasetData = {
+  mainData: DataEntry[];
+  columnsData: ColumnEntry[] | null;
+  metadata: unknown[] | null;
+};
+
 export type Dataset = Array<DataEntry>;
 
 export type FilterValues = Array<string>;


### PR DESCRIPTION
## Goal

Update the alerts dashboard client to consume `primary_dataset` and `secondary_dataset` from the alerts API so downstream client behavior no longer depends on legacy `table` / `mapeo_table` response fields. Closes #425 

## Screenshots

N/A (no visual changes expected)

## What I changed and why

- Updated the alerts page to read `primary_dataset` and `secondary_dataset` from `/api/[table]/alerts` and pass them through to the dashboard as the canonical dataset linkage
- Dashboard now uses those dataset values anywhere it previously relied on old table-style params for follow-up record fetch/export behavior
- Updated incidents composable wiring so source-table decisions align with the new dataset contract
- Added graceful handling for when `secondary_dataset` is null
- Preserves current UX while confirming the end-to-end alerts refactor path before map/gallery follow-on issues


## What I'm not doing here
N/A
## LLM use disclosure
None
