### PR TITLE
193.5: Streamline DB operations to fetch primary & secondary datasets in a single request

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,6 +1,6 @@
 import {
   fetchViewDatasets,
-  fetchData,
+  fetchViewDatasetData,
   fetchTableConfig,
 } from "@/server/database/dbOperations";
 import murmurhash from "murmurhash";
@@ -45,7 +45,15 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, metadata } = (await fetchData(primaryDataset, limit)) as {
+    const { primaryData, secondaryData } = await fetchViewDatasetData(
+      primaryDataset,
+      {
+        secondaryDataset,
+        limit,
+      },
+    );
+
+    const { mainData, metadata } = primaryData as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];
     };
@@ -74,9 +82,8 @@ export default defineEventHandler(async (event: H3Event) => {
 
     let mapeoData: FeatureCollection | null = null;
 
-    if (mapeoTable && mapeoCategoryIds) {
-      // Fetch Mapeo data
-      const rawMapeoData = await fetchData(mapeoTable);
+    if (mapeoTable && mapeoCategoryIds && secondaryData) {
+      const rawMapeoData = secondaryData;
 
       // Filter data to remove unwanted columns and substrings
       const filteredMapeoData = filterUnwantedKeys(

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import type {
   ColumnEntry,
   DataEntry,
+  FetchedDatasetData,
   RouteLevelPermission,
   ViewDatasets,
   Views,
@@ -224,6 +225,43 @@ export const fetchData = async (
   console.log("Successfully fetched data from", table, "!");
 
   return { mainData, columnsData, metadata };
+};
+
+/**
+ * Fetches primary and optional secondary dataset payloads in one DB-layer call.
+ *
+ * Endpoints that render views across multiple datasets should call this helper
+ * instead of making separate `fetchData()` calls per dataset. When
+ * `secondaryDataset` is provided, both datasets are fetched concurrently and
+ * returned in a single structured response.
+ *
+ * @param {string} primaryDataset - Required primary warehouse table name.
+ * @param {{ secondaryDataset?: string | null; limit?: number }} [options] - Optional secondary dataset and primary limit.
+ * @returns {Promise<{ primaryData: FetchedDatasetData; secondaryData: FetchedDatasetData | null }>} Fetched dataset payloads.
+ */
+export const fetchViewDatasetData = async (
+  primaryDataset: string,
+  options?: {
+    secondaryDataset?: string | null;
+    limit?: number;
+  },
+): Promise<{
+  primaryData: FetchedDatasetData;
+  secondaryData: FetchedDatasetData | null;
+}> => {
+  const primaryPromise = fetchData(primaryDataset, options?.limit);
+  if (!options?.secondaryDataset) {
+    const primaryData = (await primaryPromise) as FetchedDatasetData;
+    return { primaryData, secondaryData: null };
+  }
+
+  const secondaryPromise = fetchData(options.secondaryDataset);
+  const [primaryData, secondaryData] = (await Promise.all([
+    primaryPromise,
+    secondaryPromise,
+  ])) as [FetchedDatasetData, FetchedDatasetData];
+
+  return { primaryData, secondaryData };
 };
 
 /**

--- a/tests/unit/server/alertsEndpointDatasets.test.ts
+++ b/tests/unit/server/alertsEndpointDatasets.test.ts
@@ -2,14 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchViewDatasets = vi.fn();
 const mockFetchTableConfig = vi.fn();
-const mockFetchData = vi.fn();
+const mockFetchViewDatasetData = vi.fn();
 const mockValidatePermissions = vi.fn();
 
 vi.mock("@/server/database/dbOperations", () => ({
   fetchViewDatasets: (table: string, viewType: string) =>
     mockFetchViewDatasets(table, viewType),
   fetchTableConfig: (table: string) => mockFetchTableConfig(table),
-  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+  fetchViewDatasetData: (
+    primaryDataset: string,
+    options?: { secondaryDataset?: string | null; limit?: number },
+  ) => mockFetchViewDatasetData(primaryDataset, options),
 }));
 
 vi.mock("@/utils/accessControls", () => ({
@@ -76,10 +79,13 @@ describe("alerts endpoint dataset config", () => {
       PLANET_API_KEY: "",
     });
 
-    mockFetchData.mockResolvedValue({
-      mainData: [{ _id: "1", alertID: "a1" }],
-      columnsData: null,
-      metadata: [],
+    mockFetchViewDatasetData.mockResolvedValue({
+      primaryData: {
+        mainData: [{ _id: "1", alertID: "a1" }],
+        columnsData: null,
+        metadata: [],
+      },
+      secondaryData: null,
     });
   });
 
@@ -98,8 +104,14 @@ describe("alerts endpoint dataset config", () => {
       "alerts_confidential",
       "alerts",
     );
-    expect(mockFetchData).toHaveBeenCalledWith("alerts_confidential", 100);
-    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(mockFetchViewDatasetData).toHaveBeenCalledWith(
+      "alerts_confidential",
+      {
+        secondaryDataset: null,
+        limit: 100,
+      },
+    );
+    expect(mockFetchViewDatasetData).toHaveBeenCalledTimes(1);
     expect(response["primary_dataset"]).toBe("alerts_confidential");
     expect(response["secondary_dataset"]).toBeNull();
   });

--- a/types/index.ts
+++ b/types/index.ts
@@ -93,6 +93,12 @@ export type DataEntry = Record<string, string> & {
   normalizedId?: number;
 };
 
+export type FetchedDatasetData = {
+  mainData: DataEntry[];
+  columnsData: ColumnEntry[] | null;
+  metadata: unknown[] | null;
+};
+
 export type Dataset = Array<DataEntry>;
 
 export type FilterValues = Array<string>;


### PR DESCRIPTION
## Goal

Refactor DB operations so views that span multiple datasets can fetch primary and optional secondary dataset payloads through a single DB-layer request path. Closes #426 

## Screenshots

N/A (backend/data-layer change only)

## What I changed and why

- Introduced a shared DB helper, `fetchViewDatasetData(primaryDataset, { secondaryDataset, limit })`, that returns both primary and optional secondary dataset payloads in a single structured call as `{ primaryData, secondaryData }`
- DB layer now owns multi-dataset orchestration instead of endpoints coordinating multiple independent `fetchData()` calls, reducing duplication and establishing a stable contract for upcoming multi-dataset view work
- Wired alerts as the first consumer of the new helper, covering the existing path where both `primary_dataset` and optional `secondary_dataset` are configured
- Endpoint behavior is unchanged when `secondary_dataset` is null
- Updated test coverage to assert the new single DB-layer call path

## What I'm not doing here

This PR does not migrate map/gallery endpoints yet, and it does not change UI behavior directly. It focuses on the backend DB operations abstraction and alerts endpoint integration only.

## LLM use disclosure

Codex 5.3