### PR TITLE
193.6: API refactor for gallery view — migrate config and update endpoint

### DIFF
--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchViewDatasets,
+} from "@/server/database/dbOperations";
 import {
   filterDataByExtension,
   filterUnwantedKeys,
@@ -21,6 +25,7 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset } = await fetchViewDatasets(table, "gallery");
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -29,7 +34,7 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData, columnsData } = await fetchData(table, limit);
+    const { mainData, columnsData } = await fetchData(primaryDataset, limit);
 
     // Filter data to remove unwanted columns and substrings
     const filteredData = filterUnwantedKeys(
@@ -77,6 +82,7 @@ export default defineEventHandler(async (event: H3Event) => {
       filterColumn,
       mediaBasePath: tableConfig.MEDIA_BASE_PATH,
       mediaColumn,
+      primary_dataset: primaryDataset,
       table,
       timestampColumn: timestampColumn ?? undefined,
       rowLimitReached: mainData.length >= limit,

--- a/server/database/migrations/0009_backfill_view_config_gallery.sql
+++ b/server/database/migrations/0009_backfill_view_config_gallery.sql
@@ -1,0 +1,21 @@
+-- Backfill gallery view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_gallery" (
+  "view_id",
+  "primary_dataset"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'gallery'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776816000000,
       "tag": "0008_backfill_view_config_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777420800000,
+      "tag": "0009_backfill_view_config_gallery",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/server/galleryEndpointDatasets.test.ts
+++ b/tests/unit/server/galleryEndpointDatasets.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 50,
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterUnwantedKeys: (rows: unknown[]) => rows,
+  filterOutUnwantedValues: (rows: unknown[]) => rows,
+  filterDataByExtension: (rows: unknown[]) => rows,
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("gallery endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchViewDatasets.mockResolvedValue({
+      primaryDataset: "seed_survey_data",
+      secondaryDatasets: [],
+    });
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "anyone",
+      MEDIA_COLUMN: "photos",
+      FRONT_END_FILTER_COLUMN: "community",
+      TIMESTAMP_COLUMN: "p__created",
+      MEDIA_BASE_PATH: "https://example.com/media",
+    });
+
+    mockFetchData.mockResolvedValue({
+      mainData: [{ _id: "abc123", photos: "img.jpg" }],
+      columnsData: null,
+      metadata: null,
+    });
+  });
+
+  it("reads primary dataset from view_config_gallery and returns it in response", async () => {
+    const { default: handler } = await import("@/server/api/[table]/gallery");
+    const response = (await handler({
+      context: { params: { table: "seed_survey_data" } },
+    } as never)) as Record<string, unknown>;
+
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "seed_survey_data",
+      "gallery",
+    );
+    expect(mockFetchData).toHaveBeenCalledWith("seed_survey_data", 50);
+    expect(response["primary_dataset"]).toBe("seed_survey_data");
+  });
+});


### PR DESCRIPTION
## Goal

Migrate gallery dataset linkage from legacy `view_config.views_config` JSON into `view_config_gallery`, and update the gallery API endpoint to read its dataset source from the new table. Closes #427 

## Screenshots
<img width="812" height="250" alt="Screenshot 2026-05-06 at 09 26 15" src="https://github.com/user-attachments/assets/e20bd57c-47d7-49e4-a641-5589fb04b6ee" />



## What I changed and why

- Added a non-destructive backfill migration that copies existing gallery-configured rows into `view_config_gallery` with `view_id` and `primary_dataset`, preserving legacy config rows with safe conflict handling for reruns
- `/api/[table]/gallery` now resolves dataset linkage via `fetchViewDatasets(table, "gallery")` and uses the returned `primaryDataset` for data fetches, replacing legacy JSON linkage assumptions
- Response now exposes `primary_dataset` as a structured field, consistent with the alerts refactor


## What I'm not doing here

This PR does not redesign frontend gallery config UX and does not add any secondary dataset behavior for gallery. It is limited to migration + API refactor.

## LLM use disclosure

Used LLM assistance for SQL / Tests