### PR TITLE
Implement 7-day dependency cooldown for pnpm resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,11 @@ Please review those before submitting pull requests or issues.
 
 Any additional or overriding rules specific to this repository are listed below.
 
+## Dependency cooldown policy
+
+New JavaScript package versions must be at least 7 days old before they can be introduced.
+If dependency resolution fails due to package age, wait and retry, or select an older version.
+
 ## Icons
 
 Use `lucide-vue-next` for UI icons (Vue components), rather than inline SVGs or other icon libraries.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Copy package files
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install all dependencies (including dev dependencies for build)
 # Skip scripts to avoid Playwright installation
@@ -36,7 +36,7 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Copy package files
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install only production dependencies
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20.15.0-slim AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -33,7 +33,7 @@ FROM node:20.15.0-slim AS production
 WORKDIR /app
 
 # Install pnpm (needed for migrations)
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Goal

Add a 7-day dependency cooldown policy for pnpm so dependency resolution excludes newly published versions and lowers supply-chain risk. Closes #433 

## Screenshots

N/A (infrastructure change)

## What I changed and why

This change adds `pnpm-workspace.yaml` with `minimumReleaseAge: 10080` (7 days) to enforce release-age gating at dependency resolution time. I also updated the Docker build so `pnpm-workspace.yaml` is copied before `pnpm install` in both stages, ensuring the same policy is applied in containerized installs and not only local development.

I added a short contributor-facing policy note in `CONTRIBUTING.md` so developers understand why a dependency may be rejected for being too new and what the expected remediation is (wait or choose an older version).

## What I'm not doing here

- No package upgrades or lockfile refresh for unrelated dependencies.
- No additional trust-policy or exotic-subdependency flags.
- No exemption list additions.

## LLM use disclosure

None