### PR TITLE
193.7: Integrate primary_dataset in gallery client data flow

### DIFF
--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -30,7 +30,7 @@ const props = defineProps<{
   galleryData: Dataset;
   mediaBasePath: string;
   mediaColumn?: string;
-  table: string;
+  primaryDataset: string;
   timestampColumn?: string;
 }>();
 
@@ -77,7 +77,7 @@ const paginatedData = computed<Dataset>(() => {
 const fetchFullRecords = async (ids: string[]) => {
   loading.value = true;
   try {
-    await fetchRecords(props.table, ids);
+    await fetchRecords(props.primaryDataset, ids);
   } catch (error) {
     console.error("Error batch-fetching gallery records:", error);
   } finally {
@@ -139,7 +139,7 @@ const getFullRecord = (minimalItem: DataEntry): DataEntry => {
   // Read cacheSize to trigger Vue reactivity when cache updates
   void cacheSize.value;
   const id = String(minimalItem._id);
-  return getCachedRecord(props.table, id) ?? minimalItem;
+  return getCachedRecord(props.primaryDataset, id) ?? minimalItem;
 };
 
 /** Transform raw record for display and prepare coordinates for selected feature */

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -20,6 +20,7 @@ const filterColumn = ref();
 const galleryData = ref();
 const mediaBasePath = ref();
 const mediaColumn = ref();
+const primaryDataset = ref("");
 const timestampColumn = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/gallery`, {
@@ -35,6 +36,7 @@ if (data.value && !error.value) {
   galleryData.value = data.value.data;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaColumn.value = data.value.mediaColumn;
+  primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
 } else {
   console.error("Error fetching data:", error.value);
@@ -73,7 +75,7 @@ useHead({
         :filter-column="filterColumn"
         :media-base-path="mediaBasePath"
         :media-column="mediaColumn"
-        :table="table"
+        :primary-dataset="primaryDataset"
         :timestamp-column="timestampColumn"
       />
       <div

--- a/tests/unit/components/GalleryView.test.ts
+++ b/tests/unit/components/GalleryView.test.ts
@@ -71,7 +71,7 @@ const baseProps = {
   galleryData: [] as Dataset,
   mediaBasePath: "/",
   mediaColumn: "photo",
-  table: "t",
+  primaryDataset: "t",
 };
 
 describe("GalleryView empty states", () => {


### PR DESCRIPTION
## Goal
Use the structured `primary_dataset` returned by the gallery API as the single source of truth for gallery record and cache access in the client, aligning gallery with the alerts refactor. Closes #432 

## Screenshots 
N/A

## What I changed and why 
- Gallery page now captures `primary_dataset` from the API response and passes it into `GalleryView` as a dedicated prop
- `GalleryView` record fetching and cache lookups now use this prop instead of the route table name, removing reliance on route-derived dataset identity for client data operations
- Updated unit tests to reflect the prop rename and updated data flow

## What I'm not doing here
No UI changes

## LLM use disclosure
None
