### PR TITLE
193.8: API refactor for map view — migrate config and update endpoint

### DIFF
--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -1,4 +1,8 @@
-import { fetchData, fetchTableConfig } from "@/server/database/dbOperations";
+import {
+  fetchData,
+  fetchTableConfig,
+  fetchViewDatasets,
+} from "@/server/database/dbOperations";
 import {
   filterOutUnwantedValues,
   filterGeoData,
@@ -23,6 +27,10 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset, secondaryDatasets } = await fetchViewDatasets(
+      table,
+      "map",
+    );
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -31,7 +39,7 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const { mainData } = await fetchData(table, limit);
+    const { mainData } = await fetchData(primaryDataset, limit);
 
     // Filter data to remove unwanted values per chosen column
     const dataFilteredByValues = filterOutUnwantedValues(
@@ -89,6 +97,8 @@ export default defineEventHandler(async (event: H3Event) => {
       mediaBasePathIcons: tableConfig.MEDIA_BASE_PATH_ICONS,
       mediaColumn: tableConfig.MEDIA_COLUMN,
       planetApiKey: tableConfig.PLANET_API_KEY,
+      primary_dataset: primaryDataset,
+      secondary_datasets: secondaryDatasets,
       table,
       rowLimitReached: mainData.length >= limit,
       routeLevelPermission: tableConfig.ROUTE_LEVEL_PERMISSION,

--- a/server/database/migrations/0010_backfill_view_config_map.sql
+++ b/server/database/migrations/0010_backfill_view_config_map.sql
@@ -1,0 +1,23 @@
+-- Backfill map view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_map" (
+  "view_id",
+  "primary_dataset",
+  "secondary_datasets"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset",
+  NULL AS "secondary_datasets"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'map'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777420800000,
       "tag": "0009_backfill_view_config_gallery",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0010_backfill_view_config_map",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/server/mapEndpointDatasets.test.ts
+++ b/tests/unit/server/mapEndpointDatasets.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 50,
+}));
+
+vi.mock("@/server/utils", () => ({
+  parseBasemaps: () => ({
+    basemaps: [],
+    defaultMapboxStyle: "mapbox://styles/mapbox/streets-v12",
+  }),
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterOutUnwantedValues: (rows: unknown[]) => rows,
+  filterGeoData: (rows: unknown[]) => rows,
+}));
+
+vi.mock("@/server/dataProcessing/dataTransformers", () => ({
+  prepareMapStatistics: () => ({ pointsTotal: 0 }),
+}));
+
+vi.mock("@/utils/geoUtils", () => ({
+  buildMinimalFeatureCollection: () => ({
+    type: "FeatureCollection",
+    features: [],
+  }),
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("map endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchViewDatasets.mockResolvedValue({
+      primaryDataset: "bcmform_responses",
+      secondaryDatasets: [],
+    });
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "member",
+      FILTER_BY_COLUMN: undefined,
+      FILTER_OUT_VALUES_FROM_COLUMN: undefined,
+      COLOR_COLUMN: undefined,
+      ICON_COLUMN: undefined,
+      FRONT_END_FILTER_COLUMN: undefined,
+      TIMESTAMP_COLUMN: "p__created",
+      MAP_LEGEND_LAYER_IDS: "",
+      MAPBOX_3D: false,
+      MAPBOX_3D_TERRAIN_EXAGGERATION: 1,
+      MAPBOX_ACCESS_TOKEN: "token",
+      MAPBOX_BEARING: 0,
+      MAPBOX_CENTER_LATITUDE: "0",
+      MAPBOX_CENTER_LONGITUDE: "0",
+      MAPBOX_PITCH: 0,
+      MAPBOX_PROJECTION: "globe",
+      MAPBOX_ZOOM: 7,
+      MEDIA_BASE_PATH: "",
+      MEDIA_BASE_PATH_ICONS: "",
+      MEDIA_COLUMN: "",
+      PLANET_API_KEY: "",
+    });
+
+    mockFetchData.mockResolvedValue({
+      mainData: [{ _id: "abc" }],
+      columnsData: null,
+      metadata: null,
+    });
+  });
+
+  it("reads map datasets from view_config_map and exposes structured fields", async () => {
+    const { default: handler } = await import("@/server/api/[table]/map");
+    const response = (await handler({
+      context: { params: { table: "bcmform_responses" } },
+    } as never)) as Record<string, unknown>;
+
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "bcmform_responses",
+      "map",
+    );
+    expect(mockFetchData).toHaveBeenCalledWith("bcmform_responses", 50);
+    expect(response["primary_dataset"]).toBe("bcmform_responses");
+    expect(response["secondary_datasets"]).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Goal

Migrate map view dataset linkage from legacy JSON config to `view_config_map`, then update the map API to resolve datasets through the typed config table and expose structured dataset fields in the response. Closes #442 

## Screenshots
<img width="836" height="353" alt="Screenshot 2026-05-12 at 12 37 28" src="https://github.com/user-attachments/assets/cd4ac1ce-94fa-474e-b23e-01e174cf7018" />



## What I changed and why

- Added a non-destructive migration that backfills map view rows into `view_config_map` with `view_id` and `primary_dataset` derived from existing `view_config` data
- `secondary_datasets` is intentionally backfilled as `NULL` for this phase since map secondary datasets are not configured in the legacy model, maintaining schema/API compatibility without speculative behavior
- Map endpoint now resolves dataset linkage via `fetchViewDatasets(table, "map")` instead of implicitly using the route table as the data source
- Response now includes `primary_dataset` and `secondary_datasets`, establishing the same structured contract already in place for alerts and gallery
- Empty secondary datasets are safely normalized to `[]`
- Added a unit test verifying the new linkage path and safe handling of empty secondary datasets


## What I'm not doing here

- No map frontend changes yet (client consumption of `primary_dataset` is a follow-up issue).
- No destructive cleanup/removal of legacy `views_config` fields in this phase.

## LLM use disclosure

Used Codex to help generate migration SQL