### PR TITLE
193.9: Integrate primary_dataset param in map client

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -62,7 +62,7 @@ const props = defineProps<{
   mediaBasePathIcons?: string;
   mediaColumn?: string;
   planetApiKey?: string;
-  table: string;
+  primaryDataset: string;
   timestampColumn?: string;
 }>();
 
@@ -346,7 +346,7 @@ const addDataToMap = () => {
         // Fetch the full raw record from the single-record endpoint
         // and apply presentation transforms for display
         if (recordId) {
-          const record = await fetchRecord(props.table, recordId);
+          const record = await fetchRecord(props.primaryDataset, recordId);
           if (record) {
             const displayRecord = transformSurveyEntry(record);
             delete displayRecord["filter-color"];

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -346,6 +346,9 @@ const addDataToMap = () => {
         // Fetch the full raw record from the single-record endpoint
         // and apply presentation transforms for display
         if (recordId) {
+          // TODO: Once map secondary datasets are active, resolve record source from
+          // primary/secondary dataset linkage instead of always using primaryDataset.
+          // Epic: https://github.com/ConservationMetrics/gc-explorer/issues/437
           const record = await fetchRecord(props.primaryDataset, recordId);
           if (record) {
             const displayRecord = transformSurveyEntry(record);

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -39,6 +39,7 @@ const mediaBasePath = ref();
 const mediaBasePathIcons = ref();
 const mediaColumn = ref();
 const planetApiKey = ref();
+const primaryDataset = ref("");
 const timestampColumn = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/map`, {
@@ -71,6 +72,7 @@ if (data.value && !error.value) {
   mediaBasePathIcons.value = data.value.mediaBasePathIcons;
   mediaColumn.value = data.value.mediaColumn;
   planetApiKey.value = data.value.planetApiKey;
+  primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
 } else {
   console.error("Error fetching data:", error.value);
@@ -126,7 +128,7 @@ useHead({
         :media-base-path-icons="mediaBasePathIcons"
         :media-column="mediaColumn"
         :planet-api-key="planetApiKey"
-        :table="table"
+        :primary-dataset="primaryDataset"
         :timestamp-column="timestampColumn"
       />
     </ClientOnly>

--- a/tests/unit/components/MapView.test.ts
+++ b/tests/unit/components/MapView.test.ts
@@ -93,7 +93,7 @@ const baseProps: InstanceType<typeof MapView>["$props"] = {
   mapData: baseMapData,
   mediaBasePath: "/media",
   planetApiKey: "",
-  table: "test_table",
+  primaryDataset: "test_table",
 };
 
 Object.assign(globalThis, {


### PR DESCRIPTION
## Goal

Update the map client to consume API-provided `primary_dataset` as the dataset source of truth for map record retrieval, aligning map UI behavior with the view-config dataset refactor. Closes #443 

## Screenshots

<img width="1465" height="830" alt="Screenshot 2026-05-13 at 09 46 22" src="https://github.com/user-attachments/assets/3f64b7de-283d-4288-bace-d3856d469321" />


## What I changed and why

- Map page now stores `primary_dataset` from `/api/[table]/map` and passes it down to `MapView` as `primaryDataset`, replacing route-derived table assumptions for dataset identity
- `MapView` record cache fetch path now uses `primaryDataset` when requesting full records for selected map features, consistent with alerts and gallery

## What I'm not doing here

- No frontend usage of `secondary_datasets` yet because current map configs do not yet define active secondary tables..
- No backend/migration changes in this PR.

## LLM use disclosure

None