### PR TITLE
Resolve a few type errors relating to filters and 3d exaggeration

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -101,7 +101,7 @@ const props = defineProps<{
   mapboxBasemaps?: BasemapConfig[];
   mapboxZoom: number;
   mapbox3d: boolean;
-  mapbox3dTerrainExaggeration?: number | null;
+  mapbox3dTerrainExaggeration?: number | null | undefined;
   mapeoData: FeatureCollection | null;
   mapeoTable?: string;
   mediaBasePath: string | undefined;

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -100,7 +100,8 @@ const props = defineProps<{
   mapboxBasemaps?: BasemapConfig[];
   mapboxZoom: number;
   mapbox3d: boolean;
-  mapbox3dTerrainExaggeration: number;
+  /** From config / API; JSON may carry `null` when source was invalid (e.g. NaN). */
+  mapbox3dTerrainExaggeration?: number | null;
   mapeoData: FeatureCollection | null;
   mapeoTable?: string;
   mediaBasePath: string | undefined;
@@ -108,6 +109,13 @@ const props = defineProps<{
   planetApiKey: string | undefined;
   table: string;
 }>();
+
+const terrainExaggeration = computed(() => {
+  const v = props.mapbox3dTerrainExaggeration;
+  if (v == null) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+});
 
 const localAlertsData = ref<Feature | AlertsData>(props.alertsData);
 const calculateHectares = ref(false);
@@ -379,12 +387,12 @@ onMounted(() => {
 
   // Apply terrain whenever style loads (initial load and style changes)
   map.value.on("style.load", () => {
-    applyTerrain(map.value, props.mapbox3d, props.mapbox3dTerrainExaggeration);
+    applyTerrain(map.value, props.mapbox3d, terrainExaggeration.value);
   });
 
   map.value.on("load", async () => {
     // Add 3D Terrain if set in env var (for initial load)
-    applyTerrain(map.value, props.mapbox3d, props.mapbox3dTerrainExaggeration);
+    applyTerrain(map.value, props.mapbox3d, terrainExaggeration.value);
 
     // Only add controls once (on first load, not on style changes)
     if (!controlsAdded) {

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -16,6 +16,7 @@ import {
   applyTerrain,
   prepareMapLegendLayers,
   toggleLayerVisibility as utilsToggleLayerVisibility,
+  resolveTerrainExaggeration,
 } from "@/utils/mapGLHelpers";
 
 import BasemapSelector from "@/components/shared/BasemapSelector.vue";
@@ -100,7 +101,6 @@ const props = defineProps<{
   mapboxBasemaps?: BasemapConfig[];
   mapboxZoom: number;
   mapbox3d: boolean;
-  /** From config / API; JSON may carry `null` when source was invalid (e.g. NaN). */
   mapbox3dTerrainExaggeration?: number | null;
   mapeoData: FeatureCollection | null;
   mapeoTable?: string;
@@ -110,12 +110,9 @@ const props = defineProps<{
   table: string;
 }>();
 
-const terrainExaggeration = computed(() => {
-  const v = props.mapbox3dTerrainExaggeration;
-  if (v == null) return 0;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-});
+const terrainExaggeration = computed(() =>
+  resolveTerrainExaggeration(props.mapbox3dTerrainExaggeration),
+);
 
 const localAlertsData = ref<Feature | AlertsData>(props.alertsData);
 const calculateHectares = ref(false);

--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -26,7 +26,7 @@ const { t } = useI18n();
 
 const props = defineProps<{
   allowedFileExtensions: AllowedFileExtensions;
-  filterColumn: string;
+  filterColumn?: string;
   galleryData: Dataset;
   mediaBasePath: string;
   mediaColumn?: string;
@@ -48,7 +48,8 @@ const applyAllFilters = () => {
     filterColumn: props.filterColumn,
     selectedValues: normalizeFilterValues(selectedFilterValues.value),
     getTimestamp: (item) => (col ? item[col] : null),
-    getCategory: (item) => item[props.filterColumn],
+    getCategory: (item) =>
+      props.filterColumn != null ? item[props.filterColumn] : undefined,
   });
 };
 

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -42,7 +42,7 @@ import type {
 const props = defineProps<{
   allowedFileExtensions: AllowedFileExtensions;
   colorColumn?: string;
-  filterColumn: string;
+  filterColumn?: string;
   iconColumn?: string;
   mapStatistics: MapStatistics;
   mapLegendLayerIds?: string;
@@ -56,7 +56,7 @@ const props = defineProps<{
   mapboxBasemaps?: BasemapConfig[];
   mapboxZoom: number;
   mapbox3d: boolean;
-  mapbox3dTerrainExaggeration: number;
+  mapbox3dTerrainExaggeration?: number | null;
   mapData: FeatureCollection;
   mediaBasePath?: string;
   mediaBasePathIcons?: string;
@@ -65,6 +65,14 @@ const props = defineProps<{
   table: string;
   timestampColumn?: string;
 }>();
+
+/** Safe exaggeration for Mapbox terrain (finite number, default 0). */
+const terrainExaggeration = computed(() => {
+  const v = props.mapbox3dTerrainExaggeration;
+  if (v == null) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+});
 
 const { fetchRecord } = useRecordCache();
 
@@ -119,12 +127,12 @@ onMounted(() => {
 
   // Apply terrain whenever style loads (initial load and style changes)
   map.value.on("style.load", () => {
-    applyTerrain(map.value, props.mapbox3d, props.mapbox3dTerrainExaggeration);
+    applyTerrain(map.value, props.mapbox3d, terrainExaggeration.value);
   });
 
   map.value.on("load", () => {
     // Add 3D Terrain if set (for initial load)
-    applyTerrain(map.value, props.mapbox3d, props.mapbox3dTerrainExaggeration);
+    applyTerrain(map.value, props.mapbox3d, terrainExaggeration.value);
 
     // Only add controls once (on first load, not on style changes)
     if (!controlsAdded) {
@@ -438,7 +446,10 @@ const applyAllFilters = () => {
     filterColumn: props.filterColumn,
     selectedValues: normalizeFilterValues(selectedFilterValues.value),
     getTimestamp: (f) => f.properties?.[props.timestampColumn ?? ""],
-    getCategory: (f) => f.properties?.[props.filterColumn],
+    getCategory: (f) =>
+      props.filterColumn != null
+        ? f.properties?.[props.filterColumn]
+        : undefined,
   });
   filteredFeatureCollection.value = { type: "FeatureCollection", features };
   addDataToMap();

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -9,6 +9,7 @@ import {
   prepareMapLegendLayers,
   prepareCoordinatesForSelectedFeature,
   toggleLayerVisibility as utilsToggleLayerVisibility,
+  resolveTerrainExaggeration,
 } from "@/utils/mapGLHelpers";
 
 import DataFilter from "@/components/shared/DataFilter.vue";
@@ -66,13 +67,10 @@ const props = defineProps<{
   timestampColumn?: string;
 }>();
 
-/** Safe exaggeration for Mapbox terrain (finite number, default 0). */
-const terrainExaggeration = computed(() => {
-  const v = props.mapbox3dTerrainExaggeration;
-  if (v == null) return 0;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-});
+/** Safe exaggeration for Mapbox terrain (see {@link resolveTerrainExaggeration}). */
+const terrainExaggeration = computed(() =>
+  resolveTerrainExaggeration(props.mapbox3dTerrainExaggeration),
+);
 
 const { fetchRecord } = useRecordCache();
 

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -57,7 +57,7 @@ const props = defineProps<{
   mapboxBasemaps?: BasemapConfig[];
   mapboxZoom: number;
   mapbox3d: boolean;
-  mapbox3dTerrainExaggeration?: number | null;
+  mapbox3dTerrainExaggeration?: number | null | undefined;
   mapData: FeatureCollection;
   mediaBasePath?: string;
   mediaBasePathIcons?: string;

--- a/composables/useDateAndCategoryFilter.ts
+++ b/composables/useDateAndCategoryFilter.ts
@@ -20,7 +20,7 @@ export interface DateAndCategoryFilterOptions<T> {
   timestampColumn?: string;
   dateMin: string;
   dateMax: string;
-  filterColumn: string;
+  filterColumn?: string;
   selectedValues: string[];
   getTimestamp: (item: T) => unknown;
   getCategory: (item: T) => unknown;

--- a/utils/mapGLHelpers.ts
+++ b/utils/mapGLHelpers.ts
@@ -62,6 +62,18 @@ export const changeMapStyle = (
   }
 };
 
+/**
+ * Normalizes config/API terrain exaggeration for Mapbox.
+ * Treats null/undefined and non-finite numbers as 0 (JSON often carries `null` for NaN).
+ */
+export const resolveTerrainExaggeration = (
+  raw: number | null | undefined,
+): number => {
+  if (raw == null) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+};
+
 /** Applies or clears 3D terrain based on flags. Safe to call after style changes. */
 export const applyTerrain = (
   map: mapboxgl.Map,


### PR DESCRIPTION
## Goal

I saw in the browser console a few Nuxt warning complaints about `filterColumn` being undefined if not set, and a mismatch with its declared type (String); and Mapbox 3d Terrain not being the right expected value always (a number - 0 if not set). This PR resolves both issues.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None