### PR TITLE
view_config writes do not sync view_config_* dataset tables after migrations

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -102,11 +102,11 @@ const props = defineProps<{
   mapbox3d: boolean;
   mapbox3dTerrainExaggeration: number;
   mapeoData: FeatureCollection | null;
-  mapeoTable?: string;
+  primaryDataset: string;
+  secondaryDataset?: string | null;
   mediaBasePath: string | undefined;
   mediaBasePathAlerts: string | undefined;
   planetApiKey: string | undefined;
-  table: string;
 }>();
 
 const localAlertsData = ref<Feature | AlertsData>(props.alertsData);
@@ -167,7 +167,8 @@ const {
   route,
   router,
   toRef(props, "mapLegendLayerIds"),
-  toRef(props, "mapeoTable"),
+  toRef(props, "primaryDataset"),
+  toRef(props, "secondaryDataset"),
 );
 
 // Use feature selection composable
@@ -206,7 +207,7 @@ watch(
     }
     if (!feature) return;
 
-    const isMapeoFeature = isMapeo.value && props.mapeoTable;
+    const isMapeoFeature = isMapeo.value && !!props.secondaryDataset;
     const isMinimalAlert = !isMapeo.value && feature.alertID && feature._id;
 
     if (!isMapeoFeature && !isMinimalAlert) return;
@@ -214,7 +215,9 @@ watch(
     const recordId = feature._id || feature.id;
     if (!recordId) return;
 
-    const fetchTable = isMapeoFeature ? props.mapeoTable! : props.table;
+    const fetchTable = isMapeoFeature
+      ? props.secondaryDataset!
+      : props.primaryDataset;
     const minimalFeature = { ...feature };
     selectedFeature.value = null;
     selectedFeatureLoading.value = true;
@@ -233,7 +236,7 @@ watch(
       );
     } else {
       displayRecord = fullRecord
-        ? transformAlertEntry(fullRecord, props.table)
+        ? transformAlertEntry(fullRecord, props.primaryDataset)
         : minimalFeature;
       imageUrl.value = [];
       if (displayRecord.t0_url)
@@ -1710,7 +1713,9 @@ onBeforeUnmount(() => {
       :allowed-file-extensions="allowedFileExtensions"
       :calculate-hectares="calculateHectares"
       :date-options="dateOptions"
-      :export-table-name="isMapeo ? mapeoTable : table"
+      :export-table-name="
+        isMapeo && secondaryDataset ? secondaryDataset : primaryDataset
+      "
       :feature="selectedFeature"
       :feature-loading="selectedFeatureLoading"
       :feature-geojson="localAlertsData"

--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -30,7 +30,7 @@ const props = defineProps<{
   galleryData: Dataset;
   mediaBasePath: string;
   mediaColumn?: string;
-  table: string;
+  primaryDataset: string;
   timestampColumn?: string;
 }>();
 
@@ -77,7 +77,7 @@ const paginatedData = computed<Dataset>(() => {
 const fetchFullRecords = async (ids: string[]) => {
   loading.value = true;
   try {
-    await fetchRecords(props.table, ids);
+    await fetchRecords(props.primaryDataset, ids);
   } catch (error) {
     console.error("Error batch-fetching gallery records:", error);
   } finally {
@@ -139,7 +139,7 @@ const getFullRecord = (minimalItem: DataEntry): DataEntry => {
   // Read cacheSize to trigger Vue reactivity when cache updates
   void cacheSize.value;
   const id = String(minimalItem._id);
-  return getCachedRecord(props.table, id) ?? minimalItem;
+  return getCachedRecord(props.primaryDataset, id) ?? minimalItem;
 };
 
 /** Transform raw record for display and prepare coordinates for selected feature */

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -62,7 +62,7 @@ const props = defineProps<{
   mediaBasePathIcons?: string;
   mediaColumn?: string;
   planetApiKey?: string;
-  table: string;
+  primaryDataset: string;
   timestampColumn?: string;
 }>();
 
@@ -346,7 +346,10 @@ const addDataToMap = () => {
         // Fetch the full raw record from the single-record endpoint
         // and apply presentation transforms for display
         if (recordId) {
-          const record = await fetchRecord(props.table, recordId);
+          // TODO: Once map secondary datasets are active, resolve record source from
+          // primary/secondary dataset linkage instead of always using primaryDataset.
+          // Epic: https://github.com/ConservationMetrics/gc-explorer/issues/437
+          const record = await fetchRecord(props.primaryDataset, recordId);
           if (record) {
             const displayRecord = transformSurveyEntry(record);
             delete displayRecord["filter-color"];

--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -40,7 +40,8 @@ export const useIncidents = (
   route: RouteLocationNormalizedLoaded,
   router: Router,
   mapLegendLayerIds?: Ref<string | undefined>,
-  mapeoTableRef?: Ref<string | undefined>,
+  primaryDatasetRef?: Ref<string | undefined>,
+  secondaryDatasetRef?: Ref<string | null | undefined>,
 ) => {
   // Incidents state management
   const incidents = ref<AnnotatedCollection[]>([]);
@@ -104,15 +105,8 @@ export const useIncidents = (
 
   const SOURCE_ID_KEYS = ["alertID", "_id", "source_id", "sourceId"] as const;
 
-  /**
-   * Returns current alerts table name from route params.
-   *
-   * @returns Alerts table slug string or undefined.
-   */
   const getCurrentAlertsTable = (): string | undefined => {
-    const tableRaw = route.params.tablename;
-    if (!tableRaw) return undefined;
-    return Array.isArray(tableRaw) ? tableRaw.join("/") : String(tableRaw);
+    return primaryDatasetRef?.value;
   };
 
   /**
@@ -120,7 +114,7 @@ export const useIncidents = (
    * is the warehouse table name (often the view’s MAPEO_TABLE, or `mapeo_data`)
    */
   const savedEntryIsMapeo = (entry: CollectionEntry): boolean => {
-    const configuredMapeoTable = mapeoTableRef?.value;
+    const configuredMapeoTable = secondaryDatasetRef?.value;
     return (
       entry.source_table === "mapeo_data" ||
       (!!configuredMapeoTable && entry.source_table === configuredMapeoTable)
@@ -1091,7 +1085,7 @@ const SOURCE_ID_KEYS = ['alertID', '_id', 'source_id', 'sourceId'] as const;
       sourceTable = (tableName as string) || "";
       featureType = "alert";
     } else if (layerId.startsWith("mapeo-data")) {
-      sourceTable = mapeoTableRef?.value ?? "";
+      sourceTable = secondaryDatasetRef?.value ?? "";
       featureType = "mapeo";
     } else if (isAdditionalSelectableLayer(layerId)) {
       sourceTable = (tableName as string) || "";

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -122,6 +122,9 @@ export default defineNuxtConfig({
     dbSsl: true,
     dbTable: "",
     port: "8080",
+    maxAlertsSecondaryDatasets: 1,
+    maxMapSecondaryDatasets: 2,
+    maxGallerySecondaryDatasets: 0,
     // Session secret for nuxt-auth-utils
     sessionSecret: "your-session-secret-key-change-in-production",
     // OAuth configuration for nuxt-auth-utils

--- a/pages/alerts/[tablename].vue
+++ b/pages/alerts/[tablename].vue
@@ -33,7 +33,8 @@ const mapboxZoom = ref(0);
 const mapbox3d = ref(false);
 const mapbox3dTerrainExaggeration = ref(0);
 const mapeoData = ref();
-const mapeoTable = ref<string>();
+const primaryDataset = ref("");
+const secondaryDataset = ref<string | null>(null);
 const mediaBasePath = ref();
 const mediaBasePathAlerts = ref();
 const planetApiKey = ref();
@@ -62,8 +63,9 @@ if (data.value && !error.value) {
   mapboxZoom.value = data.value.mapboxZoom;
   mapbox3d.value = data.value.mapbox3d;
   mapbox3dTerrainExaggeration.value = data.value.mapbox3dTerrainExaggeration;
+  primaryDataset.value = data.value.primary_dataset || "";
+  secondaryDataset.value = data.value.secondary_dataset;
   mapeoData.value = data.value.mapeoData;
-  mapeoTable.value = data.value.mapeoTable;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaBasePathAlerts.value = data.value.mediaBasePathAlerts;
   planetApiKey.value = data.value.planetApiKey;
@@ -116,11 +118,11 @@ useHead({
         :mapbox3d="mapbox3d"
         :mapbox3d-terrain-exaggeration="mapbox3dTerrainExaggeration"
         :mapeo-data="mapeoData"
-        :mapeo-table="mapeoTable"
+        :primary-dataset="primaryDataset"
+        :secondary-dataset="secondaryDataset"
         :media-base-path="mediaBasePath"
         :media-base-path-alerts="mediaBasePathAlerts"
         :planet-api-key="planetApiKey"
-        :table="table"
       />
     </ClientOnly>
   </div>

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -20,6 +20,7 @@ const filterColumn = ref();
 const galleryData = ref();
 const mediaBasePath = ref();
 const mediaColumn = ref();
+const primaryDataset = ref("");
 const timestampColumn = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/gallery`, {
@@ -35,6 +36,7 @@ if (data.value && !error.value) {
   galleryData.value = data.value.data;
   mediaBasePath.value = data.value.mediaBasePath;
   mediaColumn.value = data.value.mediaColumn;
+  primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
 } else {
   console.error("Error fetching data:", error.value);
@@ -73,7 +75,7 @@ useHead({
         :filter-column="filterColumn"
         :media-base-path="mediaBasePath"
         :media-column="mediaColumn"
-        :table="table"
+        :primary-dataset="primaryDataset"
         :timestamp-column="timestampColumn"
       />
       <div

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -39,6 +39,7 @@ const mediaBasePath = ref();
 const mediaBasePathIcons = ref();
 const mediaColumn = ref();
 const planetApiKey = ref();
+const primaryDataset = ref("");
 const timestampColumn = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/map`, {
@@ -71,6 +72,7 @@ if (data.value && !error.value) {
   mediaBasePathIcons.value = data.value.mediaBasePathIcons;
   mediaColumn.value = data.value.mediaColumn;
   planetApiKey.value = data.value.planetApiKey;
+  primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
 } else {
   console.error("Error fetching data:", error.value);
@@ -126,7 +128,7 @@ useHead({
         :media-base-path-icons="mediaBasePathIcons"
         :media-column="mediaColumn"
         :planet-api-key="planetApiKey"
-        :table="table"
+        :primary-dataset="primaryDataset"
         :timestamp-column="timestampColumn"
       />
     </ClientOnly>

--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,6 +1,7 @@
 import {
   ALERTS_METADATA_PROJECTION,
-  fetchData,
+  fetchViewDatasets,
+  fetchViewDatasetData,
   fetchTableConfig,
   fetchTableSqlColumns,
 } from "@/server/database/dbOperations";
@@ -58,6 +59,11 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset, secondaryDatasets } = await fetchViewDatasets(
+      table,
+      "alerts",
+    );
+    const secondaryDataset = secondaryDatasets[0] ?? null;
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -66,7 +72,7 @@ export default defineEventHandler(async (event: H3Event) => {
     // Validate user authentication and permissions
     await validatePermissions(event, permission);
 
-    const availableMainColumns = await fetchTableSqlColumns(table);
+    const availableMainColumns = await fetchTableSqlColumns(primaryDataset);
     const alertsMainProjection = buildRequiredAlertsProjection(
       table,
       ALERTS_MAIN_PROJECTION,
@@ -75,18 +81,23 @@ export default defineEventHandler(async (event: H3Event) => {
       "Alerts dashboard datasets",
     );
     const availableMetadataColumns = await fetchTableSqlColumns(
-      `${table}__metadata`,
+      `${primaryDataset}__metadata`,
     );
     const alertsMetadataProjection = ALERTS_METADATA_PROJECTION.filter(
       (columnName) => availableMetadataColumns.includes(columnName),
     );
 
-    const { mainData, metadata } = (await fetchData(table, {
-      limit,
-      mainColumns: alertsMainProjection,
-      includeMetadata: alertsMetadataProjection.length > 0,
-      metadataColumns: alertsMetadataProjection,
-    })) as {
+    const { primaryData, secondaryData } = await fetchViewDatasetData(
+      primaryDataset,
+      {
+        secondaryDataset,
+        limit,
+        primaryMainColumns: alertsMainProjection,
+        primaryMetadataColumns: alertsMetadataProjection,
+      },
+    );
+
+    const { mainData, metadata } = primaryData as {
       mainData: DataEntry[];
       metadata: AlertsMetadata[];
     };
@@ -110,18 +121,13 @@ export default defineEventHandler(async (event: H3Event) => {
       ),
     };
 
-    const mapeoTable = tableConfig.MAPEO_TABLE;
+    const mapeoTable = secondaryDataset;
     const mapeoCategoryIds = tableConfig.MAPEO_CATEGORY_IDS;
 
     let mapeoData: FeatureCollection | null = null;
 
-    if (mapeoTable && mapeoCategoryIds) {
-      const mapeoMainColumns = await fetchTableSqlColumns(mapeoTable);
-      // Fetch Mapeo data with explicit projection.
-      const rawMapeoData = await fetchData(mapeoTable, {
-        mainColumns: mapeoMainColumns,
-        includeColumnsData: true,
-      });
+    if (mapeoTable && mapeoCategoryIds && secondaryData) {
+      const rawMapeoData = secondaryData;
 
       // Filter data to remove unwanted columns and substrings
       const filteredMapeoData = filterUnwantedKeys(
@@ -179,6 +185,8 @@ export default defineEventHandler(async (event: H3Event) => {
       mapboxStyle: defaultMapboxStyle,
       mapboxBasemaps: basemaps,
       mapboxZoom: Number(tableConfig.MAPBOX_ZOOM),
+      primary_dataset: primaryDataset,
+      secondary_dataset: secondaryDataset,
       mapeoTable,
       mapeoData,
       mediaBasePath: tableConfig.MEDIA_BASE_PATH,

--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -2,6 +2,7 @@ import {
   fetchData,
   fetchTableConfig,
   fetchTableSqlColumns,
+  fetchViewDatasets,
 } from "@/server/database/dbOperations";
 import {
   filterDataByExtension,
@@ -25,6 +26,7 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset } = await fetchViewDatasets(table, "gallery");
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -50,9 +52,9 @@ export default defineEventHandler(async (event: H3Event) => {
             ].filter((column): column is string => Boolean(column)),
           ),
         )
-      : await fetchTableSqlColumns(table);
+      : await fetchTableSqlColumns(primaryDataset);
 
-    const { mainData, columnsData } = await fetchData(table, {
+    const { mainData, columnsData } = await fetchData(primaryDataset, {
       limit,
       mainColumns: projectedColumns,
       includeColumnsData: true,
@@ -100,6 +102,7 @@ export default defineEventHandler(async (event: H3Event) => {
       filterColumn,
       mediaBasePath: tableConfig.MEDIA_BASE_PATH,
       mediaColumn,
+      primary_dataset: primaryDataset,
       table,
       timestampColumn: timestampColumn ?? undefined,
       rowLimitReached: mainData.length >= limit,

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -2,6 +2,7 @@ import {
   fetchData,
   fetchTableConfig,
   fetchTableSqlColumns,
+  fetchViewDatasets,
 } from "@/server/database/dbOperations";
 import {
   filterOutUnwantedValues,
@@ -27,6 +28,10 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const { primaryDataset, secondaryDatasets } = await fetchViewDatasets(
+      table,
+      "map",
+    );
     const tableConfig = await fetchTableConfig(table);
 
     // Check visibility permissions
@@ -41,7 +46,7 @@ export default defineEventHandler(async (event: H3Event) => {
     const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
     const filterByColumn = tableConfig.FILTER_BY_COLUMN;
 
-    const tableSqlColumns = await fetchTableSqlColumns(table);
+    const tableSqlColumns = await fetchTableSqlColumns(primaryDataset);
     const dateLikeColumns = tableSqlColumns.filter((column) =>
       /(date|time|created|modified|updated)/i.test(column),
     );
@@ -60,7 +65,7 @@ export default defineEventHandler(async (event: H3Event) => {
         ].filter((column): column is string => Boolean(column)),
       ),
     );
-    const { mainData } = await fetchData(table, {
+    const { mainData } = await fetchData(primaryDataset, {
       limit,
       mainColumns,
     });
@@ -116,6 +121,8 @@ export default defineEventHandler(async (event: H3Event) => {
       mediaBasePathIcons: tableConfig.MEDIA_BASE_PATH_ICONS,
       mediaColumn: tableConfig.MEDIA_COLUMN,
       planetApiKey: tableConfig.PLANET_API_KEY,
+      primary_dataset: primaryDataset,
+      secondary_datasets: secondaryDatasets,
       table,
       rowLimitReached: mainData.length >= limit,
       routeLevelPermission: tableConfig.ROUTE_LEVEL_PERMISSION,

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -4,13 +4,24 @@ import type {
   ColumnEntry,
   DataEntry,
   FetchDataOptions,
+  FetchedDatasetData,
   RouteLevelPermission,
+  ViewDatasets,
   Views,
   ViewConfig,
+  ViewType,
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
+import { splitCsv } from "@/utils/csvUtils";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 
-import { viewConfig, publicViews } from "./schema";
+import {
+  viewConfig,
+  viewConfigAlerts,
+  viewConfigGallery,
+  viewConfigMap,
+  publicViews,
+} from "./schema";
 import { configDb, warehouseDb } from "./dbConnection";
 
 /**
@@ -28,6 +39,93 @@ const createMissingViewConfigError = (table: string) => {
   error.statusCode = 404;
   error.statusMessage = statusMessage;
   return error;
+};
+
+const createMissingViewDatasetConfigError = (
+  table: string,
+  viewType: ViewType,
+) => {
+  const statusMessage = `No ${viewType} dataset configuration found for table "${table}"`;
+  const error = new Error(statusMessage) as Error & {
+    statusCode: number;
+    statusMessage: string;
+  };
+  error.statusCode = 404;
+  error.statusMessage = statusMessage;
+  return error;
+};
+
+type ViewDatasetSpec = {
+  table:
+    | typeof viewConfigAlerts
+    | typeof viewConfigMap
+    | typeof viewConfigGallery;
+  viewIdColumn:
+    | typeof viewConfigAlerts.viewId
+    | typeof viewConfigMap.viewId
+    | typeof viewConfigGallery.viewId;
+  primaryColumn:
+    | typeof viewConfigAlerts.primaryDataset
+    | typeof viewConfigMap.primaryDataset
+    | typeof viewConfigGallery.primaryDataset;
+  secondarySelections?: Record<string, AnyPgColumn>;
+  extractSecondary?: (row: Record<string, unknown>) => string[];
+};
+
+const VIEW_DATASET_SPECS: Record<ViewType, ViewDatasetSpec> = {
+  alerts: {
+    table: viewConfigAlerts,
+    viewIdColumn: viewConfigAlerts.viewId,
+    primaryColumn: viewConfigAlerts.primaryDataset,
+    secondarySelections: {
+      secondaryDataset: viewConfigAlerts.secondaryDataset,
+    },
+    extractSecondary: (row) => {
+      const value = row.secondaryDataset;
+      return typeof value === "string" && value.length > 0 ? [value] : [];
+    },
+  },
+  map: {
+    table: viewConfigMap,
+    viewIdColumn: viewConfigMap.viewId,
+    primaryColumn: viewConfigMap.primaryDataset,
+    secondarySelections: { secondaryDatasets: viewConfigMap.secondaryDatasets },
+    extractSecondary: (row) =>
+      splitCsv(
+        typeof row.secondaryDatasets === "string"
+          ? row.secondaryDatasets
+          : null,
+      ),
+  },
+  gallery: {
+    table: viewConfigGallery,
+    viewIdColumn: viewConfigGallery.viewId,
+    primaryColumn: viewConfigGallery.primaryDataset,
+  },
+};
+
+const queryViewDatasets = async (
+  spec: ViewDatasetSpec,
+  viewId: string,
+): Promise<ViewDatasets | null> => {
+  const [row] = (await configDb
+    .select({
+      primaryDataset: spec.primaryColumn,
+      ...(spec.secondarySelections ?? {}),
+    })
+    .from(spec.table)
+    .where(eq(spec.viewIdColumn, viewId))
+    .limit(1)) as Array<Record<string, unknown>>;
+
+  const primary = row?.primaryDataset;
+  if (typeof primary !== "string" || primary.length === 0) {
+    return null;
+  }
+
+  return {
+    primaryDataset: primary,
+    secondaryDatasets: spec.extractSecondary?.(row) ?? [],
+  };
 };
 
 /**
@@ -282,6 +380,62 @@ export const fetchData = async (
 };
 
 /**
+ * Fetches primary and optional secondary dataset payloads in one DB-layer call.
+ *
+ * Endpoints that render views across multiple datasets should call this helper
+ * instead of making separate `fetchData()` calls per dataset. When
+ * `secondaryDataset` is provided, both datasets are fetched concurrently and
+ * returned in a single structured response.
+ *
+ * @param {string} primaryDataset - Required primary warehouse table name.
+ * @param {{ secondaryDataset?: string | null; limit?: number }} [options] - Optional secondary dataset and primary limit.
+ * @returns {Promise<{ primaryData: FetchedDatasetData; secondaryData: FetchedDatasetData | null }>} Fetched dataset payloads.
+ */
+export const fetchViewDatasetData = async (
+  primaryDataset: string,
+  options?: {
+    secondaryDataset?: string | null;
+    limit?: number;
+    primaryMainColumns?: string[];
+    primaryMetadataColumns?: string[];
+    secondaryMainColumns?: string[];
+  },
+): Promise<{
+  primaryData: FetchedDatasetData;
+  secondaryData: FetchedDatasetData | null;
+}> => {
+  const primaryMainColumns =
+    options?.primaryMainColumns ?? (await fetchTableSqlColumns(primaryDataset));
+  const primaryMetadataColumns =
+    options?.primaryMetadataColumns ??
+    (await fetchTableSqlColumns(`${primaryDataset}__metadata`));
+  const primaryPromise = fetchData(primaryDataset, {
+    limit: options?.limit,
+    mainColumns: primaryMainColumns,
+    includeMetadata: primaryMetadataColumns.length > 0,
+    metadataColumns: primaryMetadataColumns,
+  });
+  if (!options?.secondaryDataset) {
+    const primaryData = (await primaryPromise) as FetchedDatasetData;
+    return { primaryData, secondaryData: null };
+  }
+
+  const secondaryMainColumns =
+    options?.secondaryMainColumns ??
+    (await fetchTableSqlColumns(options.secondaryDataset));
+  const secondaryPromise = fetchData(options.secondaryDataset, {
+    mainColumns: secondaryMainColumns,
+    includeColumnsData: true,
+  });
+  const [primaryData, secondaryData] = (await Promise.all([
+    primaryPromise,
+    secondaryPromise,
+  ])) as [FetchedDatasetData, FetchedDatasetData];
+
+  return { primaryData, secondaryData };
+};
+
+/**
  * Fetches a single raw record from the warehouse database by its _id column.
  * Returns the record exactly as stored — no transformations or filtering.
  *
@@ -512,6 +666,67 @@ export const fetchTableConfig = async (table: string): Promise<ViewConfig> => {
       throw error;
     }
     console.error(`Error fetching config for table "${table}":`, error);
+    throw error;
+  }
+};
+
+/**
+ * Resolves dataset table linkage for a single view instance.
+ *
+ * This is the shared lookup used by all view endpoints that need to know which
+ * warehouse table(s) to query. It reads from the per-view-type config tables
+ * (`view_config_alerts`, `view_config_map`, `view_config_gallery`) and returns a
+ * normalized shape (`primaryDataset`, `secondaryDatasets[]`) for route handlers.
+ *
+ * Typical usage:
+ * - alerts endpoint: `fetchViewDatasets(table, "alerts")`
+ * - map endpoint: `fetchViewDatasets(table, "map")`
+ * - gallery endpoint: `fetchViewDatasets(table, "gallery")`
+ *
+ * @param {string} table - View identifier (currently `view_id` / route table param).
+ * @param {ViewType} viewType - Which view config table should be queried.
+ * @returns {Promise<ViewDatasets>} Normalized primary + secondary dataset list.
+ * @throws {Error} 404-style error when no dataset config exists for that view.
+ */
+export const fetchViewDatasets = async (
+  table: string,
+  viewType: ViewType,
+): Promise<ViewDatasets> => {
+  if (process.env.CI) {
+    const viewsConfig = await fetchConfig();
+    const tableConfig = viewsConfig[table];
+    if (!tableConfig) {
+      throw createMissingViewDatasetConfigError(table, viewType);
+    }
+
+    const secondaryDatasets =
+      viewType === "alerts" && tableConfig.MAPEO_TABLE
+        ? [tableConfig.MAPEO_TABLE]
+        : [];
+
+    return {
+      primaryDataset: table,
+      secondaryDatasets,
+    };
+  }
+
+  try {
+    const datasets = await queryViewDatasets(
+      VIEW_DATASET_SPECS[viewType],
+      table,
+    );
+    if (!datasets) {
+      throw createMissingViewDatasetConfigError(table, viewType);
+    }
+    return datasets;
+  } catch (error) {
+    if (error instanceof Error && "statusCode" in error) {
+      throw error;
+    }
+    console.error(
+      `Error fetching ${viewType} datasets for table "${table}":`,
+      error,
+    );
     throw error;
   }
 };

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -129,6 +129,96 @@ const queryViewDatasets = async (
 };
 
 /**
+ * Extracts supported view types from config.VIEWS.
+ *
+ * @param {ViewConfig} config - Parsed table config payload.
+ * @returns {Set<ViewType>} Supported view types configured for this table.
+ */
+const getConfiguredViewTypes = (config: ViewConfig): Set<ViewType> => {
+  const configured = splitCsv(config.VIEWS).map((value) => value.toLowerCase());
+  const supportedTypes: ViewType[] = ["alerts", "map", "gallery"];
+  return new Set(
+    configured.filter((value): value is ViewType =>
+      supportedTypes.includes(value as ViewType),
+    ),
+  );
+};
+
+/**
+ * Keeps per-view-type config tables in sync with one view_config row.
+ *
+ * @param {string} tableName - View identifier / table_name.
+ * @param {ViewConfig} config - Parsed config values for this table.
+ * @returns {Promise<void>} Resolves when all per-view-type rows are synced.
+ */
+const syncViewTypeConfigs = async (
+  tableName: string,
+  config: ViewConfig,
+): Promise<void> => {
+  const configuredViews = getConfiguredViewTypes(config);
+  const secondaryDataset = config.MAPEO_TABLE?.trim() || null;
+
+  if (configuredViews.has("alerts")) {
+    await configDb
+      .insert(viewConfigAlerts)
+      .values({
+        viewId: tableName,
+        primaryDataset: tableName,
+        secondaryDataset,
+      })
+      .onConflictDoUpdate({
+        target: viewConfigAlerts.viewId,
+        set: {
+          primaryDataset: tableName,
+          secondaryDataset,
+        },
+      });
+  } else {
+    await configDb
+      .delete(viewConfigAlerts)
+      .where(eq(viewConfigAlerts.viewId, tableName));
+  }
+
+  if (configuredViews.has("map")) {
+    await configDb
+      .insert(viewConfigMap)
+      .values({
+        viewId: tableName,
+        primaryDataset: tableName,
+        secondaryDatasets: null,
+      })
+      .onConflictDoUpdate({
+        target: viewConfigMap.viewId,
+        set: {
+          primaryDataset: tableName,
+          secondaryDatasets: null,
+        },
+      });
+  } else {
+    await configDb
+      .delete(viewConfigMap)
+      .where(eq(viewConfigMap.viewId, tableName));
+  }
+
+  if (configuredViews.has("gallery")) {
+    await configDb
+      .insert(viewConfigGallery)
+      .values({
+        viewId: tableName,
+        primaryDataset: tableName,
+      })
+      .onConflictDoUpdate({
+        target: viewConfigGallery.viewId,
+        set: { primaryDataset: tableName },
+      });
+  } else {
+    await configDb
+      .delete(viewConfigGallery)
+      .where(eq(viewConfigGallery.viewId, tableName));
+  }
+};
+
+/**
  * Ensures the config database contains a `view_config` table before reads/writes.
  *
  * @returns {Promise<void>} Resolves when the table exists.
@@ -800,6 +890,7 @@ export const updateConfig = async (
       })
       .where(eq(viewConfig.tableName, tableName));
 
+    await syncViewTypeConfigs(tableName, typedConfig);
     await syncPublicViews(tableName, typedConfig.ROUTE_LEVEL_PERMISSION);
   } catch (error) {
     console.error("Error updating config:", error);
@@ -813,6 +904,7 @@ export const addNewTableToConfig = async (tableName: string): Promise<void> => {
       tableName,
       viewsConfig: "{}",
     });
+    await syncViewTypeConfigs(tableName, {});
   } catch (error) {
     console.error("Error adding new table to config:", error);
     throw error;

--- a/server/database/migrations/0007_create_view_type_config_tables.sql
+++ b/server/database/migrations/0007_create_view_type_config_tables.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS "view_config_alerts" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  "secondary_dataset" text,
+  CONSTRAINT "view_config_alerts_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "view_config_map" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  "secondary_datasets" text,
+  CONSTRAINT "view_config_map_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "view_config_gallery" (
+  "view_id" text PRIMARY KEY NOT NULL,
+  "primary_dataset" text NOT NULL,
+  CONSTRAINT "view_config_gallery_view_id_fk"
+    FOREIGN KEY ("view_id")
+    REFERENCES "view_config" ("table_name")
+    ON DELETE CASCADE
+);

--- a/server/database/migrations/0008_backfill_view_config_alerts.sql
+++ b/server/database/migrations/0008_backfill_view_config_alerts.sql
@@ -1,0 +1,23 @@
+-- Backfill alert view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_alerts" (
+  "view_id",
+  "primary_dataset",
+  "secondary_dataset"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset",
+  NULLIF(BTRIM((vc."views_config"::jsonb ->> 'MAPEO_TABLE')), '') AS "secondary_dataset"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'alerts'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/0009_backfill_view_config_gallery.sql
+++ b/server/database/migrations/0009_backfill_view_config_gallery.sql
@@ -1,0 +1,21 @@
+-- Backfill gallery view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_gallery" (
+  "view_id",
+  "primary_dataset"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'gallery'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/0010_backfill_view_config_map.sql
+++ b/server/database/migrations/0010_backfill_view_config_map.sql
@@ -1,0 +1,23 @@
+-- Backfill map view configuration into first-class columns.
+-- Non-destructive: source rows in view_config are preserved.
+INSERT INTO "view_config_map" (
+  "view_id",
+  "primary_dataset",
+  "secondary_datasets"
+)
+SELECT
+  vc."table_name" AS "view_id",
+  vc."table_name" AS "primary_dataset",
+  NULL AS "secondary_datasets"
+FROM "view_config" vc
+WHERE EXISTS (
+  SELECT 1
+  FROM UNNEST(
+    STRING_TO_ARRAY(
+      COALESCE(vc."views_config"::jsonb ->> 'VIEWS', ''),
+      ','
+    )
+  ) AS configured_view(view_name)
+  WHERE BTRIM(configured_view.view_name) = 'map'
+)
+ON CONFLICT ("view_id") DO NOTHING;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -50,6 +50,34 @@
       "when": 1768207769008,
       "tag": "0006_backfill_parent_alerts_table_incidents",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776729600000,
+      "tag": "0007_create_view_type_config_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776816000000,
+      "tag": "0008_backfill_view_config_alerts",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777420800000,
+      "tag": "0009_backfill_view_config_gallery",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0010_backfill_view_config_map",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,5 +1,10 @@
 // Import all schemas
 import { viewConfig } from "./schemas/viewConfig";
+import {
+  viewConfigAlerts,
+  viewConfigMap,
+  viewConfigGallery,
+} from "./schemas/viewConfigByType";
 import { publicViews } from "./schemas/publicViews";
 import {
   annotatedCollections,
@@ -9,11 +14,15 @@ import {
 
 // Re-export all schemas from separate files
 export * from "./schemas/viewConfig";
+export * from "./schemas/viewConfigByType";
 export * from "./schemas/publicViews";
 export * from "./schemas/annotatedCollections";
 
 export const schemas = {
   viewConfig,
+  viewConfigAlerts,
+  viewConfigMap,
+  viewConfigGallery,
   publicViews,
   annotatedCollections,
   incidents,

--- a/server/database/schemas/viewConfigByType.ts
+++ b/server/database/schemas/viewConfigByType.ts
@@ -1,0 +1,27 @@
+import { pgTable, text } from "drizzle-orm/pg-core";
+
+import { viewConfig } from "./viewConfig";
+
+export const viewConfigAlerts = pgTable("view_config_alerts", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+  secondaryDataset: text("secondary_dataset"),
+});
+
+export const viewConfigMap = pgTable("view_config_map", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+  // Keep this list-based to avoid schema migrations when max changes.
+  secondaryDatasets: text("secondary_datasets"),
+});
+
+export const viewConfigGallery = pgTable("view_config_gallery", {
+  viewId: text("view_id")
+    .primaryKey()
+    .references(() => viewConfig.tableName, { onDelete: "cascade" }),
+  primaryDataset: text("primary_dataset").notNull(),
+});

--- a/server/utils/dbHelpers.ts
+++ b/server/utils/dbHelpers.ts
@@ -36,3 +36,38 @@ export const parseAndValidateLimit = (event: H3Event): number => {
   const maxLimit = Number(useRuntimeConfig(event).public.rowLimit);
   return validateRowLimit(raw, maxLimit);
 };
+
+/**
+ * Parses a comma-separated secondary dataset list into a normalized array.
+ * Keeps first occurrence order, removes blanks, deduplicates, and enforces max.
+ */
+export const getSecondaryDatasets = (input: unknown, max = 2): string[] => {
+  if (typeof input !== "string" || max <= 0) {
+    return [];
+  }
+
+  const values = input
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  const unique: string[] = [];
+  for (const value of values) {
+    if (!unique.includes(value)) {
+      unique.push(value);
+    }
+  }
+
+  return unique.slice(0, max);
+};
+
+/**
+ * Converts secondary datasets to storage form for `view_config_map.secondary_datasets`.
+ */
+export const normalizeSecondaryDatasets = (
+  input: unknown,
+  max = 2,
+): string | null => {
+  const datasets = getSecondaryDatasets(input, max);
+  return datasets.length > 0 ? datasets.join(",") : null;
+};

--- a/tests/unit/components/AlertsDashboard.test.ts
+++ b/tests/unit/components/AlertsDashboard.test.ts
@@ -67,10 +67,11 @@ const baseProps: InstanceType<typeof AlertsDashboard>["$props"] = {
   mapbox3d: false,
   mapbox3dTerrainExaggeration: 1.5,
   mapeoData: null,
+  primaryDataset: "test_alerts",
+  secondaryDataset: null,
   mediaBasePath: "",
   mediaBasePathAlerts: "",
   planetApiKey: "",
-  table: "test_alerts",
 };
 
 // Mock Nuxt composables - needs to be before component import

--- a/tests/unit/components/GalleryView.test.ts
+++ b/tests/unit/components/GalleryView.test.ts
@@ -71,7 +71,7 @@ const baseProps = {
   galleryData: [] as Dataset,
   mediaBasePath: "/",
   mediaColumn: "photo",
-  table: "t",
+  primaryDataset: "t",
 };
 
 describe("GalleryView empty states", () => {

--- a/tests/unit/components/MapView.test.ts
+++ b/tests/unit/components/MapView.test.ts
@@ -93,7 +93,7 @@ const baseProps: InstanceType<typeof MapView>["$props"] = {
   mapData: baseMapData,
   mediaBasePath: "/media",
   planetApiKey: "",
-  table: "test_table",
+  primaryDataset: "test_table",
 };
 
 Object.assign(globalThis, {

--- a/tests/unit/server/alertsEndpointDatasets.test.ts
+++ b/tests/unit/server/alertsEndpointDatasets.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchTableSqlColumns = vi.fn();
+const mockFetchViewDatasetData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  ALERTS_METADATA_PROJECTION: [
+    "data_source",
+    "type_alert",
+    "month",
+    "year",
+    "day",
+    "total_alerts",
+    "description_alerts",
+    "territory",
+  ],
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchTableSqlColumns: (table: string) => mockFetchTableSqlColumns(table),
+  fetchViewDatasetData: (
+    primaryDataset: string,
+    options?: {
+      secondaryDataset?: string | null;
+      limit?: number;
+      primaryMainColumns?: string[];
+      primaryMetadataColumns?: string[];
+    },
+  ) => mockFetchViewDatasetData(primaryDataset, options),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils", () => ({
+  parseBasemaps: () => ({
+    basemaps: [],
+    defaultMapboxStyle: "mapbox://styles/mapbox/streets-v12",
+  }),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 100,
+}));
+
+vi.mock("@/server/dataProcessing/dataTransformers", () => ({
+  prepareMinimalAlertEntries: (mainData: unknown[]) => ({
+    mostRecentAlerts: mainData,
+    previousAlerts: [],
+  }),
+  prepareAlertsStatistics: () => ({ alertsTotal: 0 }),
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterUnwantedKeys: (rows: unknown[]) => rows,
+  filterGeoData: (rows: unknown[]) => rows,
+}));
+
+vi.mock("@/utils/geoUtils", () => ({
+  buildMinimalFeatureCollection: () => ({
+    type: "FeatureCollection",
+    features: [],
+  }),
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("alerts endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "anyone",
+      MAPEO_CATEGORY_IDS: "threat",
+      MAPBOX_3D: false,
+      MAPBOX_ZOOM: 7,
+      MAPBOX_BEARING: 0,
+      MAPBOX_CENTER_LATITUDE: "0",
+      MAPBOX_CENTER_LONGITUDE: "0",
+      MAPBOX_PITCH: 0,
+      MAPBOX_PROJECTION: "globe",
+      MAPBOX_ACCESS_TOKEN: "token",
+      MAPBOX_STYLE: "mapbox://styles/mapbox/streets-v12",
+      MEDIA_BASE_PATH: "",
+      MEDIA_BASE_PATH_ALERTS: "",
+      PLANET_API_KEY: "",
+    });
+
+    mockFetchViewDatasetData.mockResolvedValue({
+      primaryData: {
+        mainData: [{ _id: "1", alertID: "a1" }],
+        columnsData: null,
+        metadata: [],
+      },
+      secondaryData: null,
+    });
+
+    mockFetchTableSqlColumns.mockImplementation((table: string) => {
+      if (table === "alerts_confidential") {
+        return Promise.resolve([
+          "_id",
+          "alert_id",
+          "month_detec",
+          "year_detec",
+          "g__type",
+          "g__coordinates",
+          "alert_type",
+        ]);
+      }
+      if (table === "alerts_confidential__metadata") {
+        return Promise.resolve(["data_source", "year", "month", "territory"]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  it("returns structured dataset fields and tolerates null secondary dataset", async () => {
+    mockFetchViewDatasets.mockResolvedValue({
+      primaryDataset: "alerts_confidential",
+      secondaryDatasets: [],
+    });
+
+    const { default: handler } = await import("@/server/api/[table]/alerts");
+    const response = (await handler({
+      context: { params: { table: "alerts_confidential" } },
+    } as never)) as Record<string, unknown>;
+
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "alerts_confidential",
+      "alerts",
+    );
+    expect(mockFetchViewDatasetData).toHaveBeenCalledWith(
+      "alerts_confidential",
+      expect.objectContaining({
+        secondaryDataset: null,
+        limit: 100,
+        primaryMainColumns: expect.arrayContaining([
+          "_id",
+          "alert_id",
+          "month_detec",
+          "year_detec",
+          "g__type",
+          "g__coordinates",
+        ]),
+      }),
+    );
+    expect(mockFetchViewDatasetData).toHaveBeenCalledTimes(1);
+    expect(response["primary_dataset"]).toBe("alerts_confidential");
+    expect(response["secondary_dataset"]).toBeNull();
+  });
+});

--- a/tests/unit/server/galleryEndpointDatasets.test.ts
+++ b/tests/unit/server/galleryEndpointDatasets.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchData: (table: string, limit?: number) => mockFetchData(table, limit),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 50,
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterUnwantedKeys: (rows: unknown[]) => rows,
+  filterOutUnwantedValues: (rows: unknown[]) => rows,
+  filterDataByExtension: (rows: unknown[]) => rows,
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("gallery endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchViewDatasets.mockResolvedValue({
+      primaryDataset: "seed_survey_data",
+      secondaryDatasets: [],
+    });
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "anyone",
+      MEDIA_COLUMN: "photos",
+      FRONT_END_FILTER_COLUMN: "community",
+      TIMESTAMP_COLUMN: "p__created",
+      MEDIA_BASE_PATH: "https://example.com/media",
+    });
+
+    mockFetchData.mockResolvedValue({
+      mainData: [{ _id: "abc123", photos: "img.jpg" }],
+      columnsData: null,
+      metadata: null,
+    });
+  });
+
+  it("reads primary dataset from view_config_gallery and returns it in response", async () => {
+    const { default: handler } = await import("@/server/api/[table]/gallery");
+    const response = (await handler({
+      context: { params: { table: "seed_survey_data" } },
+    } as never)) as Record<string, unknown>;
+
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "seed_survey_data",
+      "gallery",
+    );
+    expect(mockFetchData).toHaveBeenCalledWith("seed_survey_data", {
+      limit: 50,
+      mainColumns: ["_id", "community", "p__created", "photos"],
+      includeColumnsData: true,
+    });
+    expect(response["primary_dataset"]).toBe("seed_survey_data");
+  });
+});

--- a/tests/unit/server/mapEndpointDatasets.test.ts
+++ b/tests/unit/server/mapEndpointDatasets.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchViewDatasets = vi.fn();
+const mockFetchTableConfig = vi.fn();
+const mockFetchTableSqlColumns = vi.fn();
+const mockFetchData = vi.fn();
+const mockValidatePermissions = vi.fn();
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchViewDatasets: (table: string, viewType: string) =>
+    mockFetchViewDatasets(table, viewType),
+  fetchTableConfig: (table: string) => mockFetchTableConfig(table),
+  fetchTableSqlColumns: (table: string) => mockFetchTableSqlColumns(table),
+  fetchData: (table: string, options: unknown) => mockFetchData(table, options),
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: (event: unknown, permission?: string) =>
+    mockValidatePermissions(event, permission),
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: () => 50,
+}));
+
+vi.mock("@/server/utils", () => ({
+  parseBasemaps: () => ({
+    basemaps: [],
+    defaultMapboxStyle: "mapbox://styles/mapbox/streets-v12",
+  }),
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterOutUnwantedValues: (rows: unknown[]) => rows,
+  filterGeoData: (rows: unknown[]) => rows,
+}));
+
+vi.mock("@/server/dataProcessing/dataTransformers", () => ({
+  prepareMapStatistics: () => ({ pointsTotal: 0 }),
+}));
+
+vi.mock("@/utils/geoUtils", () => ({
+  buildMinimalFeatureCollection: () => ({
+    type: "FeatureCollection",
+    features: [],
+  }),
+}));
+
+vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
+vi.stubGlobal("useRuntimeConfig", () => ({
+  public: {
+    allowedFileExtensions: { image: [], audio: [], video: [] },
+  },
+}));
+
+describe("map endpoint dataset config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetchViewDatasets.mockResolvedValue({
+      primaryDataset: "bcmform_responses",
+      secondaryDatasets: [],
+    });
+
+    mockFetchTableConfig.mockResolvedValue({
+      ROUTE_LEVEL_PERMISSION: "member",
+      FILTER_BY_COLUMN: undefined,
+      FILTER_OUT_VALUES_FROM_COLUMN: undefined,
+      COLOR_COLUMN: undefined,
+      ICON_COLUMN: undefined,
+      FRONT_END_FILTER_COLUMN: undefined,
+      TIMESTAMP_COLUMN: "p__created",
+      MAP_LEGEND_LAYER_IDS: "",
+      MAPBOX_3D: false,
+      MAPBOX_3D_TERRAIN_EXAGGERATION: 1,
+      MAPBOX_ACCESS_TOKEN: "token",
+      MAPBOX_BEARING: 0,
+      MAPBOX_CENTER_LATITUDE: "0",
+      MAPBOX_CENTER_LONGITUDE: "0",
+      MAPBOX_PITCH: 0,
+      MAPBOX_PROJECTION: "globe",
+      MAPBOX_ZOOM: 7,
+      MEDIA_BASE_PATH: "",
+      MEDIA_BASE_PATH_ICONS: "",
+      MEDIA_COLUMN: "",
+      PLANET_API_KEY: "",
+    });
+
+    mockFetchData.mockResolvedValue({
+      mainData: [{ _id: "abc" }],
+      columnsData: null,
+      metadata: null,
+    });
+
+    mockFetchTableSqlColumns.mockResolvedValue([
+      "_id",
+      "g__type",
+      "g__coordinates",
+      "p__created",
+    ]);
+  });
+
+  it("reads map datasets from view_config_map and exposes structured fields", async () => {
+    const { default: handler } = await import("@/server/api/[table]/map");
+    const response = (await handler({
+      context: { params: { table: "bcmform_responses" } },
+    } as never)) as Record<string, unknown>;
+
+    expect(mockFetchViewDatasets).toHaveBeenCalledWith(
+      "bcmform_responses",
+      "map",
+    );
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "bcmform_responses",
+      expect.objectContaining({
+        limit: 50,
+        mainColumns: expect.arrayContaining([
+          "_id",
+          "g__type",
+          "g__coordinates",
+          "p__created",
+        ]),
+      }),
+    );
+    expect(response["primary_dataset"]).toBe("bcmform_responses");
+    expect(response["secondary_datasets"]).toEqual([]);
+  });
+});

--- a/tests/unit/server/secondaryDatasets.test.ts
+++ b/tests/unit/server/secondaryDatasets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSecondaryDatasets,
+  normalizeSecondaryDatasets,
+} from "@/server/utils/dbHelpers";
+
+describe("getSecondaryDatasets", () => {
+  it("returns empty array for non-string inputs", () => {
+    expect(getSecondaryDatasets(undefined)).toEqual([]);
+    expect(getSecondaryDatasets(null)).toEqual([]);
+    expect(getSecondaryDatasets(123)).toEqual([]);
+  });
+
+  it("parses, trims and removes blanks", () => {
+    expect(getSecondaryDatasets("  foo, bar ,, baz  ", 10)).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  it("deduplicates while preserving first-seen order", () => {
+    expect(getSecondaryDatasets("foo,bar,foo,baz,bar", 10)).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  it("enforces max datasets", () => {
+    expect(getSecondaryDatasets("a,b,c,d", 2)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array when max is 0 or less", () => {
+    expect(getSecondaryDatasets("a,b", 0)).toEqual([]);
+    expect(getSecondaryDatasets("a,b", -1)).toEqual([]);
+  });
+});
+
+describe("normalizeSecondaryDatasets", () => {
+  it("serializes normalized datasets as comma-separated string", () => {
+    expect(normalizeSecondaryDatasets("a,b,a,c", 2)).toBe("a,b");
+  });
+
+  it("returns null when no valid secondary datasets", () => {
+    expect(normalizeSecondaryDatasets(" , ", 2)).toBeNull();
+    expect(normalizeSecondaryDatasets(undefined, 2)).toBeNull();
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -66,6 +66,13 @@ export interface Views {
   [key: string]: ViewConfig;
 }
 
+export type ViewType = "alerts" | "map" | "gallery";
+
+export interface ViewDatasets {
+  primaryDataset: string;
+  secondaryDatasets: string[];
+}
+
 export type AllowedFileExtensions = {
   audio: string[];
   image: string[];
@@ -93,6 +100,12 @@ export type FetchDataOptions = {
   includeMetadata?: boolean;
   columnsTableColumns?: string[];
   metadataColumns?: string[];
+};
+
+export type FetchedDatasetData = {
+  mainData: DataEntry[];
+  columnsData: ColumnEntry[] | null;
+  metadata: unknown[] | null;
 };
 
 export type Dataset = Array<DataEntry>;

--- a/utils/csvUtils.ts
+++ b/utils/csvUtils.ts
@@ -23,6 +23,16 @@ export const escapeCSVValue = (value: unknown): string => {
 };
 
 /**
+ * Splits comma-separated values into a trimmed non-empty list.
+ * Useful for config fields that store list-like values in one text column.
+ */
+export const splitCsv = (value: string | null | undefined): string[] =>
+  (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+/**
  * Builds a CSV string from tabular rows with a fixed header order (like dataset export).
  * Objects and arrays are JSON-stringified for a single cell.
  */


### PR DESCRIPTION
## Goal

Fix the runtime config sync gap where `view_config` updates could leave `view_config_alerts`, `view_config_map`, and `view_config_gallery` out of date after initial migrations. Closes #457 

## Screenshots

N/A 

## What I changed and why

- Added a centralized sync helper in `server/database/dbOperations.ts` that derives configured view types from `VIEWS` and keeps per-view config tables aligned with each `view_config` row
- Helper upserts rows into `view_config_alerts`, `view_config_map`, and `view_config_gallery` when their view types are present, and deletes stale rows when view types are removed
- For alerts, `MAPEO_TABLE` is carried over into `secondary_dataset` where applicable
- Wired the sync into both `updateConfig()` and `addNewTableToConfig()` so per-view tables are maintained at write time instead of depending on one-time migration backfills



## What I'm not doing here

- Not changing migration files or startup migration behavior.
- Not modifying frontend behavior.

## LLM use disclosure

Codex 5.3 and Osa