### PR TITLE
Remove pattern attributes in media config

### DIFF
--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -265,7 +265,6 @@ onMounted(() => {
             type="text"
             :value="shareInputBasePath"
             placeholder="https://files.example.com/share/abc123 or abc123"
-            pattern="^(https?://[^\s]+/(?:share|api/public/dl)/[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)$"
             @input="
               handleInput('basePath', ($event.target as HTMLInputElement).value)
             "
@@ -366,7 +365,6 @@ onMounted(() => {
             type="text"
             :value="shareInputAlerts"
             placeholder="https://files.example.com/share/abc123 or abc123"
-            pattern="^(https?://[^\s]+/(?:share|api/public/dl)/[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)$"
             @input="
               handleInput('alerts', ($event.target as HTMLInputElement).value)
             "
@@ -467,7 +465,6 @@ onMounted(() => {
             type="text"
             :value="shareInputIcons"
             placeholder="https://files.example.com/share/abc123 or abc123"
-            pattern="^(https?://[^\s]+/(?:share|api/public/dl)/[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)$"
             @input="
               handleInput('icons', ($event.target as HTMLInputElement).value)
             "


### PR DESCRIPTION
## Goal

I was seeing some errors in Chrome browser console logs when saving a config:

```js
Pattern attribute value ^(https?://[^\s]+/(?:share|api/public/dl)/[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)$ is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /^(https?://[^\s]+/(?:share|api/public/dl)/[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)$/v: Invalid character in character classUnderstand this error
```

This is because we were using `pattern` attribute for media inputs, and Chrome rejects `/` and `:` as bare characters inside character classes. Anyway, turns out these added `pattern` attributes are not even useful, since we already handle the exact same validations in lifecycle computation, so this PR rips them out.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None