### PR TITLE
Fix mobile viewport whitespace below map

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -650,8 +650,9 @@ body {
 #map {
   position: absolute;
   top: 0;
-  bottom: 0;
+  left: 0;
   width: 100%;
+  height: 100dvh;
 }
 
 .mapboxgl-popup-content {


### PR DESCRIPTION
## Goal

The map container used `position: absolute; top: 0; bottom: 0;` which sizes it to the initial containing block. On mobile, the ICB is locked to the small viewport (address bar visible), so when the browser chrome collapses on scroll, the visible viewport grows but the map doesn't, leaving whitespace beneath it. I've seen this a few times on my phone.

Switched to `height: 100dvh`, which tracks the actual visible viewport as mobile browser chrome shows/hides.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None