### PR TITLE
On `MapView`, move down filter group on mobile

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -576,7 +576,9 @@ onBeforeUnmount(() => {
     >
       {{ $t("resetMap") }}
     </button>
-    <div class="absolute top-4 right-14 z-10 flex flex-col gap-0.5">
+    <div
+      class="absolute top-16 sm:top-4 right-14 z-10 flex flex-col gap-0.5"
+    >
       <DataFilter
         v-if="filterColumn"
         :key="`filter-${filterResetKey}`"

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -576,9 +576,7 @@ onBeforeUnmount(() => {
     >
       {{ $t("resetMap") }}
     </button>
-    <div
-      class="absolute top-16 sm:top-4 right-14 z-10 flex flex-col gap-0.5"
-    >
+    <div class="absolute top-16 sm:top-4 right-14 z-10 flex flex-col gap-0.5">
       <DataFilter
         v-if="filterColumn"
         :key="`filter-${filterResetKey}`"


### PR DESCRIPTION
## Goal

Just a minor improvement to bump the filter group down a bit on mobile viewports, so as to avoid it from covering the "Reset Map" button.

## Screenshots

Before:
<img width="488" height="313" alt="image" src="https://github.com/user-attachments/assets/06b06956-7e19-4826-aa08-4994a54161ab" />

After: 
<img width="488" height="313" alt="image" src="https://github.com/user-attachments/assets/b8311002-cd34-4855-96bf-1dfa4f7884ca" />

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None