### PR TITLE
Add "How I convinced myself this is right" to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@ Please read our [Contributor License Agreement and other Contributing Guidelines
 ## What I changed and why
 
 
+## How I convinced myself this is right
+
+
 ## What I'm not doing here
 
 


### PR DESCRIPTION


## Goal

Update pull request template to prompt authors to verify their work and share that process with the reviewers.

## How I convinced myself this is right

The section header is intentionally open-ended.
Answers can be short (one-liner "added a test and it passes"). They might describe a process and its result ("Latency before XX vs after YY for 30% improvement"). They might have artifacts: I ran the app locally and here's a screencast.

Basically we want to hear that **process** that happened beyond writing code: either extra verification steps or thought process to reach confidence.

If you thought about edge cases or how this fits in to the bigger picture, here's where you can say that.

## What I'm not doing here

Not adding example answers to the new section. That's aligned with all the other sections too. I believe that seeding it would constrain responses and undermine the open-ended intent.

If we agree with this here, I'll roll out the change to other repos via direct commit (skipping PR).

## LLM use disclosure
Claude Sonnet suggested this wording over what I've used at a previous org, "How I know this works."

