### PR TITLE
Remove vestigial API keys

### DIFF
--- a/composables/useRecordCache.ts
+++ b/composables/useRecordCache.ts
@@ -43,11 +43,6 @@ const ensureCacheCount = (): Ref<number> => {
  * State is module-level so every consumer shares one cache keyed by `table::recordId`.
  */
 export const useRecordCache = () => {
-  const {
-    public: { appApiKey },
-  } = useRuntimeConfig();
-
-  const headers = { "x-api-key": appApiKey as string };
   const count = ensureCacheCount();
 
   /**

--- a/composables/useRecordCache.ts
+++ b/composables/useRecordCache.ts
@@ -69,7 +69,7 @@ export const useRecordCache = () => {
       return pending.get(cacheKey)!;
     }
 
-    const request = $fetch<DataEntry>(`/api/${table}/${recordId}`, { headers })
+    const request = $fetch<DataEntry>(`/api/${table}/${recordId}`)
       .then((record) => {
         cache.set(cacheKey, record);
         maybeEvictOldestCacheEntry();
@@ -131,7 +131,6 @@ export const useRecordCache = () => {
         $fetch<DataEntry[]>(`/api/${table}/records`, {
           method: "POST",
           body: { ids: batch },
-          headers,
         }),
       );
       const batchResults = await Promise.all(batchPromises);

--- a/tests/unit/composables/useRecordCache.test.ts
+++ b/tests/unit/composables/useRecordCache.test.ts
@@ -35,9 +35,7 @@ describe("useRecordCache", () => {
     const result = await fetchRecord("my_table", "abc");
 
     expect(result).toEqual(mockRecord);
-    expect(mockFetch).toHaveBeenCalledWith("/api/my_table/abc", {
-      headers: { "x-api-key": "test-key" },
-    });
+    expect(mockFetch).toHaveBeenCalledWith("/api/my_table/abc");
   });
 
   it("returns cached record on subsequent calls without hitting the API", async () => {
@@ -194,7 +192,6 @@ describe("useRecordCache - bulk fetch", () => {
     expect(mockFetch).toHaveBeenLastCalledWith("/api/my_table/records", {
       method: "POST",
       body: { ids: ["b2"] },
-      headers: { "x-api-key": "test-key" },
     });
   });
 


### PR DESCRIPTION
## Goal

To remove some leftover API keys in headers that are no longer used in the app.