### PR TITLE
Gallery: componentize grid tiles (4 desktop / 2 mobile) — rounded chrome for all media

### DIFF
--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -5,13 +5,12 @@ import {
   normalizeFilterValues,
   useTimestampFilter,
 } from "@/composables/useDateAndCategoryFilter";
-import { prepareCoordinatesForSelectedFeature } from "@/utils/mapGLHelpers";
 import { useRecordCache } from "@/composables/useRecordCache";
-import { transformSurveyEntry } from "@/utils/dataTransformers";
 
 import DataFilter from "@/components/shared/DataFilter.vue";
 import TimestampFilter from "@/components/shared/TimestampFilter.vue";
-import DataFeature from "@/components/shared/DataFeature.vue";
+import GalleryGrid from "@/components/gallery/GalleryGrid.vue";
+import GalleryTile from "@/components/gallery/GalleryTile.vue";
 import EmptyStateIllustration from "@/components/shared/EmptyStateIllustration.vue";
 import { useI18n } from "vue-i18n";
 
@@ -143,15 +142,12 @@ const getFullRecord = (minimalItem: DataEntry): DataEntry => {
   return getCachedRecord(props.table, id) ?? minimalItem;
 };
 
-/** Transform raw record for display and prepare coordinates for selected feature */
-const prepareForDisplay = (feature: DataEntry): DataEntry => {
-  const transformed = transformSurveyEntry(feature);
-  if (transformed.geocoordinates) {
-    transformed.geocoordinates = prepareCoordinatesForSelectedFeature(
-      transformed.geocoordinates,
-    );
-  }
-  return transformed;
+const getRecordFilePaths = (feature: DataEntry): string[] => {
+  return getFilePathsWithExtension(
+    feature,
+    props.allowedFileExtensions,
+    props.mediaColumn,
+  );
 };
 </script>
 
@@ -159,11 +155,11 @@ const prepareForDisplay = (feature: DataEntry): DataEntry => {
   <div
     id="galleryContainer"
     data-testid="gallery-container"
-    class="gallery p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+    class="gallery p-4"
   >
     <div
       v-if="filterColumn || timestampColumn"
-      class="sticky top-10 right-10 z-10 flex flex-col gap-0.5"
+      class="sticky top-10 right-10 z-10 flex flex-col gap-0.5 mb-4"
       data-testid="filter-container"
     >
       <DataFilter
@@ -181,7 +177,7 @@ const prepareForDisplay = (feature: DataEntry): DataEntry => {
     </div>
     <div
       v-if="filteredData.length === 0"
-      class="col-span-full text-center py-12"
+      class="text-center py-12"
       data-testid="gallery-empty-state"
     >
       <EmptyStateIllustration
@@ -191,22 +187,16 @@ const prepareForDisplay = (feature: DataEntry): DataEntry => {
         {{ emptyStateMessage }}
       </p>
     </div>
-    <DataFeature
-      v-for="(feature, index) in paginatedData"
-      v-else
-      :key="feature._id ?? index"
-      :allowed-file-extensions="allowedFileExtensions"
-      :feature="prepareForDisplay(getFullRecord(feature))"
-      :file-paths="
-        getFilePathsWithExtension(
-          getFullRecord(feature),
-          allowedFileExtensions,
-          mediaColumn,
-        )
-      "
-      :media-base-path="mediaBasePath"
-      :data-testid="`gallery-item-${index}`"
-    />
+    <GalleryGrid v-else>
+      <GalleryTile
+        v-for="(feature, index) in paginatedData"
+        :key="feature._id ?? index"
+        :allowed-file-extensions="allowedFileExtensions"
+        :file-paths="getRecordFilePaths(getFullRecord(feature))"
+        :media-base-path="mediaBasePath"
+        :test-id="`gallery-item-${index}`"
+      />
+    </GalleryGrid>
     <!-- Hidden element to track pagination state for testing -->
     <div
       data-testid="pagination-info"

--- a/components/gallery/GalleryGrid.vue
+++ b/components/gallery/GalleryGrid.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-4" data-testid="gallery-grid">
+    <slot></slot>
+  </div>
+</template>

--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -35,9 +35,10 @@ const handleTileKeydown = (event: KeyboardEvent) => {
     @click="handleTileClick"
     @keydown="handleTileKeydown"
   >
-    <div class="relative overflow-hidden rounded-2xl">
+    <div class="relative w-full aspect-square overflow-hidden rounded-2xl">
       <MediaFile
         v-if="previewFilePath"
+        class="h-full w-full"
         :allowed-file-extensions="allowedFileExtensions"
         :file-path="previewFilePath"
         :media-base-path="mediaBasePath"

--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -28,7 +28,7 @@ const previewFilePath = computed(() => props.filePaths[0] ?? null);
       data-testid="gallery-tile-no-media"
     >
       <span class="text-sm text-violet-700 text-center">{{
-        $t("galleryNoMedia")
+        $t("galleryEmpty")
       }}</span>
     </div>
   </div>

--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import MediaFile from "@/components/shared/MediaFile.vue";
+
+import type { AllowedFileExtensions } from "@/types";
+
+const props = defineProps<{
+  allowedFileExtensions: AllowedFileExtensions;
+  filePaths: string[];
+  mediaBasePath: string;
+  testId: string;
+}>();
+
+const previewFilePath = computed(() => props.filePaths[0] ?? null);
+</script>
+
+<template>
+  <div class="overflow-hidden rounded-2xl" :data-testid="testId">
+    <MediaFile
+      v-if="previewFilePath"
+      :allowed-file-extensions="allowedFileExtensions"
+      :file-path="previewFilePath"
+      :media-base-path="mediaBasePath"
+      variant="gallery"
+    />
+    <div
+      v-else
+      class="aspect-square rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center p-4"
+      data-testid="gallery-tile-no-media"
+    >
+      <span class="text-sm text-violet-700 text-center">{{
+        $t("galleryNoMedia")
+      }}</span>
+    </div>
+  </div>
+</template>

--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -11,25 +11,59 @@ const props = defineProps<{
 }>();
 
 const previewFilePath = computed(() => props.filePaths[0] ?? null);
+
+const handleTileClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  if (target.closest("audio, video, a")) {
+    return;
+  }
+};
+
+const handleTileKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+  }
+};
 </script>
 
 <template>
-  <div class="overflow-hidden rounded-2xl" :data-testid="testId">
-    <MediaFile
-      v-if="previewFilePath"
-      :allowed-file-extensions="allowedFileExtensions"
-      :file-path="previewFilePath"
-      :media-base-path="mediaBasePath"
-      variant="gallery"
-    />
-    <div
-      v-else
-      class="aspect-square rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center p-4"
-      data-testid="gallery-tile-no-media"
-    >
-      <span class="text-sm text-violet-700 text-center">{{
-        $t("galleryNoMedia")
-      }}</span>
+  <div
+    class="group relative rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2"
+    :data-testid="testId"
+    tabindex="0"
+    role="button"
+    @click="handleTileClick"
+    @keydown="handleTileKeydown"
+  >
+    <div class="relative overflow-hidden rounded-2xl">
+      <MediaFile
+        v-if="previewFilePath"
+        :allowed-file-extensions="allowedFileExtensions"
+        :file-path="previewFilePath"
+        :media-base-path="mediaBasePath"
+        variant="gallery"
+      />
+      <div
+        v-else
+        class="aspect-square rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center p-4"
+        data-testid="gallery-tile-no-media"
+      >
+        <span class="text-sm text-violet-700 text-center">{{
+          $t("galleryNoMedia")
+        }}</span>
+      </div>
+
+      <div
+        v-if="previewFilePath"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-70 transition-opacity duration-300 lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100"
+        data-testid="gallery-tile-overlay"
+      >
+        <span
+          class="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-black/30"
+        >
+          {{ $t("galleryClickToViewDetails") }}
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/components/shared/MediaFile.vue
+++ b/components/shared/MediaFile.vue
@@ -92,7 +92,7 @@ const handleImageLoad = () => {
 
 const imageContainerClass = computed(() => {
   if (isGalleryVariant.value) {
-    return "w-full aspect-square overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-800";
+    return "w-full h-full overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-800";
   }
   return "w-full aspect-video rounded-lg bg-gray-100 dark:bg-gray-800";
 });
@@ -106,11 +106,14 @@ const imageClass = computed(() => {
 </script>
 
 <template>
-  <div>
+  <div :class="{ 'h-full w-full': isGalleryVariant }">
     <div
       v-if="isImage"
       ref="imageContainer"
-      :class="isGalleryVariant ? '' : 'mb-4'"
+      :class="[
+        isGalleryVariant ? 'h-full w-full' : '',
+        isGalleryVariant ? '' : 'mb-4',
+      ]"
     >
       <!-- Error state: Show red X icon when image fails to load (404) -->
       <div
@@ -190,7 +193,7 @@ const imageClass = computed(() => {
       v-if="isAudio"
       :class="
         isGalleryVariant
-          ? 'overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 aspect-square flex items-center'
+          ? 'h-full w-full overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 flex items-center'
           : 'mb-4'
       "
     >
@@ -210,7 +213,7 @@ const imageClass = computed(() => {
       v-if="isVideo"
       :class="
         isGalleryVariant
-          ? 'overflow-hidden rounded-2xl aspect-square bg-gray-100'
+          ? 'h-full w-full overflow-hidden rounded-2xl bg-gray-100'
           : 'mb-4'
       "
     >

--- a/components/shared/MediaFile.vue
+++ b/components/shared/MediaFile.vue
@@ -4,11 +4,19 @@ import type { AllowedFileExtensions } from "@/types";
 import { useIntersectionObserver } from "@/composables/useIntersectionObserver";
 import { useOptimizedImages } from "@/composables/useOptimizedImages";
 
-const props = defineProps<{
-  allowedFileExtensions: AllowedFileExtensions;
-  filePath: string;
-  mediaBasePath: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    allowedFileExtensions: AllowedFileExtensions;
+    filePath: string;
+    mediaBasePath: string;
+    variant?: "default" | "gallery";
+  }>(),
+  {
+    variant: "default",
+  },
+);
+
+const isGalleryVariant = computed(() => props.variant === "gallery");
 
 /** Conditional rendering based on file extension */
 const isAudio = computed(() =>
@@ -81,15 +89,36 @@ const handleImageLoad = () => {
   imageError.value = false;
   imageLoaded.value = true;
 };
+
+const imageContainerClass = computed(() => {
+  if (isGalleryVariant.value) {
+    return "w-full aspect-square overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-800";
+  }
+  return "w-full aspect-video rounded-lg bg-gray-100 dark:bg-gray-800";
+});
+
+const imageClass = computed(() => {
+  if (isGalleryVariant.value) {
+    return "w-full h-full object-cover";
+  }
+  return "w-full h-auto rounded-lg";
+});
 </script>
 
 <template>
   <div>
-    <div v-if="isImage" ref="imageContainer" class="mb-4">
+    <div
+      v-if="isImage"
+      ref="imageContainer"
+      :class="isGalleryVariant ? '' : 'mb-4'"
+    >
       <!-- Error state: Show red X icon when image fails to load (404) -->
       <div
         v-if="shouldLoadImage && imageError"
-        class="w-full aspect-video rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center border-2 border-red-500"
+        :class="[
+          imageContainerClass,
+          'flex items-center justify-center border-2 border-red-500',
+        ]"
       >
         <div
           class="flex flex-col items-center justify-center gap-2 text-red-500"
@@ -106,7 +135,7 @@ const handleImageLoad = () => {
         v-else-if="
           !shouldLoadImage || (shouldLoadImage && !imageLoaded && !imageError)
         "
-        class="w-full aspect-video rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center"
+        :class="[imageContainerClass, 'flex items-center justify-center']"
       >
         <div class="text-gray-400 text-sm">
           {{ $t("loading") || "Loading..." }}
@@ -115,7 +144,7 @@ const handleImageLoad = () => {
 
       <!-- Image container: Load and show image when in viewport -->
       <a
-        v-if="shouldLoadImage && !imageError"
+        v-if="shouldLoadImage && !imageError && !isGalleryVariant"
         :href="rawImageUrl"
         target="_blank"
         :data-lightbox="filePath"
@@ -126,14 +155,27 @@ const handleImageLoad = () => {
         <img
           :src="optimizedImageUrl"
           alt="Image"
-          class="w-full h-auto rounded-lg"
+          :class="imageClass"
           @load="handleImageLoad"
           @error="handleImageError"
         />
       </a>
 
       <div
-        v-if="filePath"
+        v-if="shouldLoadImage && !imageError && isGalleryVariant"
+        :class="[imageContainerClass, { hidden: !imageLoaded }]"
+      >
+        <img
+          :src="optimizedImageUrl"
+          alt="Image"
+          :class="imageClass"
+          @load="handleImageLoad"
+          @error="handleImageError"
+        />
+      </div>
+
+      <div
+        v-if="filePath && !isGalleryVariant"
         class="text-center flex items-center justify-center mt-2"
       >
         <span v-if="filePath.includes('t0.jpg')" class="italic">{{
@@ -144,8 +186,15 @@ const handleImageLoad = () => {
         }}</span>
       </div>
     </div>
-    <div v-if="isAudio" class="mb-4">
-      <audio controls class="w-full" preload="none">
+    <div
+      v-if="isAudio"
+      :class="
+        isGalleryVariant
+          ? 'overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 aspect-square flex items-center'
+          : 'mb-4'
+      "
+    >
+      <audio controls class="w-full" preload="none" @click.stop>
         <source
           :src="mediaBasePath + '/' + filePath"
           :type="
@@ -157,8 +206,24 @@ const handleImageLoad = () => {
         {{ $t("browserDoesntSupportAudio") }}.
       </audio>
     </div>
-    <div v-if="isVideo" class="mb-4">
-      <video controls class="w-full h-auto rounded-lg" preload="none">
+    <div
+      v-if="isVideo"
+      :class="
+        isGalleryVariant
+          ? 'overflow-hidden rounded-2xl aspect-square bg-gray-100'
+          : 'mb-4'
+      "
+    >
+      <video
+        controls
+        :class="
+          isGalleryVariant
+            ? 'w-full h-full object-cover'
+            : 'w-full h-auto rounded-lg'
+        "
+        preload="none"
+        @click.stop
+      >
         <source
           :src="mediaBasePath + '/' + filePath"
           :type="'video/' + getExtension(filePath)"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -91,6 +91,7 @@
   "gallery": "Gallery",
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryNoFilterResults": "No items match the current filters.",
+  "galleryNoMedia": "No media available",
   "galleryNotAvailable": "The gallery view is not yet configured for this dataset",
   "geocoordinates": "Coordinates",
   "geographicCentroid": "Geographic centroid",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "filtering": "Filtering",
   "filterOutValuesFromColumn": "Which values to filter out from the column",
   "gallery": "Gallery",
+  "galleryClickToViewDetails": "Click to view details",
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryNoFilterResults": "No items match the current filters.",
   "galleryNoMedia": "No media available",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -91,7 +91,6 @@
   "gallery": "Gallery",
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryNoFilterResults": "No items match the current filters.",
-  "galleryNoMedia": "No media available",
   "galleryNotAvailable": "The gallery view is not yet configured for this dataset",
   "geocoordinates": "Coordinates",
   "geographicCentroid": "Geographic centroid",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -88,7 +88,6 @@
   "gallery": "Galería",
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryNoFilterResults": "Ningún elemento coincide con los filtros actuales.",
-  "galleryNoMedia": "No hay medios disponibles",
   "galleryNotAvailable": "La vista de galería no está configurada para este conjunto de datos",
   "geocoordinates": "Coordenadas",
   "geographicCentroid": "Centroide geográfico",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -86,6 +86,7 @@
   "filtering": "Filtrado",
   "filterOutValuesFromColumn": "Qué valores filtrar de la columna",
   "gallery": "Galería",
+  "galleryClickToViewDetails": "Haz clic para ver detalles",
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryNoFilterResults": "Ningún elemento coincide con los filtros actuales.",
   "galleryNoMedia": "No hay medios disponibles",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -88,6 +88,7 @@
   "gallery": "Galería",
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryNoFilterResults": "Ningún elemento coincide con los filtros actuales.",
+  "galleryNoMedia": "No hay medios disponibles",
   "galleryNotAvailable": "La vista de galería no está configurada para este conjunto de datos",
   "geocoordinates": "Coordenadas",
   "geographicCentroid": "Centroide geográfico",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -89,7 +89,6 @@
   "gallery": "Galerij",
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryNoFilterResults": "Geen items komen overeen met de huidige filters.",
-  "galleryNoMedia": "Geen media beschikbaar",
   "galleryNotAvailable": "De galerijweergave is niet voor deze dataset geconfigureerd",
   "geocoordinates": "Coördinaten",
   "geographicCentroid": "Geografisch middelpunt",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -89,6 +89,7 @@
   "gallery": "Galerij",
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryNoFilterResults": "Geen items komen overeen met de huidige filters.",
+  "galleryNoMedia": "Geen media beschikbaar",
   "galleryNotAvailable": "De galerijweergave is niet voor deze dataset geconfigureerd",
   "geocoordinates": "Coördinaten",
   "geographicCentroid": "Geografisch middelpunt",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -87,6 +87,7 @@
   "filtering": "Filteren",
   "filterOutValuesFromColumn": "Welke waarden uit de kolom filteren",
   "gallery": "Galerij",
+  "galleryClickToViewDetails": "Klik om details te bekijken",
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryNoFilterResults": "Geen items komen overeen met de huidige filters.",
   "galleryNoMedia": "Geen media beschikbaar",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -88,6 +88,7 @@
   "gallery": "Galeria",
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryNoFilterResults": "Nenhum item corresponde aos filtros atuais.",
+  "galleryNoMedia": "Nenhuma mídia disponível",
   "galleryNotAvailable": "A visualização de galeria não está configurada para este conjunto de dados",
   "geocoordinates": "Coordenadas",
   "geographicCentroid": "Centróide geográfico",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -86,6 +86,7 @@
   "filtering": "Filtragem",
   "filterOutValuesFromColumn": "Quais valores filtrar da coluna",
   "gallery": "Galeria",
+  "galleryClickToViewDetails": "Clique para ver detalhes",
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryNoFilterResults": "Nenhum item corresponde aos filtros atuais.",
   "galleryNoMedia": "Nenhuma mídia disponível",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -88,7 +88,6 @@
   "gallery": "Galeria",
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryNoFilterResults": "Nenhum item corresponde aos filtros atuais.",
-  "galleryNoMedia": "Nenhuma mídia disponível",
   "galleryNotAvailable": "A visualização de galeria não está configurada para este conjunto de dados",
   "geocoordinates": "Coordenadas",
   "geographicCentroid": "Centróide geográfico",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -91,7 +91,6 @@
   "gallery": "Matunzio",
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryNoFilterResults": "Hakuna vipengele vinavyolingana na vichujio vya sasa.",
-  "galleryNoMedia": "Hakuna media inayopatikana",
   "galleryNotAvailable": "Mtazamo wa matunzio bado haujasanidiwa kwa seti hii ya data",
   "geocoordinates": "Vituo vya jiografia",
   "geographicCentroid": "Kitovu cha jiografia",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -91,6 +91,7 @@
   "gallery": "Matunzio",
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryNoFilterResults": "Hakuna vipengele vinavyolingana na vichujio vya sasa.",
+  "galleryNoMedia": "Hakuna media inayopatikana",
   "galleryNotAvailable": "Mtazamo wa matunzio bado haujasanidiwa kwa seti hii ya data",
   "geocoordinates": "Vituo vya jiografia",
   "geographicCentroid": "Kitovu cha jiografia",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -89,6 +89,7 @@
   "filtering": "Kuchuja",
   "filterOutValuesFromColumn": "Thamani gani za kuchuja kutoka safuni",
   "gallery": "Matunzio",
+  "galleryClickToViewDetails": "Bofya kuona maelezo",
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryNoFilterResults": "Hakuna vipengele vinavyolingana na vichujio vya sasa.",
   "galleryNoMedia": "Hakuna media inayopatikana",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -91,7 +91,6 @@
   "gallery": "แกลเลอรี",
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryNoFilterResults": "ไม่มีรายการตรงกับตัวกรองปัจจุบัน",
-  "galleryNoMedia": "ไม่มีสื่อ",
   "galleryNotAvailable": "มุมมองแกลเลอรียังไม่ได้ตั้งค่าสำหรับชุดข้อมูลนี้",
   "geocoordinates": "พิกัด",
   "geographicCentroid": "จุดศูนย์กลางทางภูมิศาสตร์",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -91,6 +91,7 @@
   "gallery": "แกลเลอรี",
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryNoFilterResults": "ไม่มีรายการตรงกับตัวกรองปัจจุบัน",
+  "galleryNoMedia": "ไม่มีสื่อ",
   "galleryNotAvailable": "มุมมองแกลเลอรียังไม่ได้ตั้งค่าสำหรับชุดข้อมูลนี้",
   "geocoordinates": "พิกัด",
   "geographicCentroid": "จุดศูนย์กลางทางภูมิศาสตร์",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -89,6 +89,7 @@
   "filtering": "การกรอง",
   "filterOutValuesFromColumn": "ค่าที่ต้องการกรองออกจากคอลัมน์",
   "gallery": "แกลเลอรี",
+  "galleryClickToViewDetails": "คลิกเพื่อดูรายละเอียด",
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryNoFilterResults": "ไม่มีรายการตรงกับตัวกรองปัจจุบัน",
   "galleryNoMedia": "ไม่มีสื่อ",

--- a/tests/unit/components/GalleryView.test.ts
+++ b/tests/unit/components/GalleryView.test.ts
@@ -13,8 +13,6 @@ Object.assign(globalThis, {
   onBeforeUnmount,
 });
 
-// TODO: Add more unit tests for GalleryView behavior beyond empty states.
-
 const mockT = (key: string) => key;
 vi.mock("vue-i18n", () => ({
   useI18n: () => ({ t: mockT }),
@@ -28,7 +26,7 @@ vi.mock("@/composables/useRecordCache", () => ({
   }),
 }));
 
-const filterByDateAndCategoryMock = vi.fn();
+const filterByDateAndCategoryMock = vi.fn((data: Dataset) => data);
 vi.mock("@/composables/useDateAndCategoryFilter", () => ({
   filterByDateAndCategory: (...args: unknown[]) =>
     filterByDateAndCategoryMock(...args),
@@ -41,7 +39,7 @@ vi.mock("@/composables/useDateAndCategoryFilter", () => ({
 }));
 
 vi.mock("@/utils", () => ({
-  getFilePathsWithExtension: () => [],
+  getFilePathsWithExtension: () => ["photo.jpg"],
 }));
 
 const globalConfig = {
@@ -52,7 +50,13 @@ const globalConfig = {
       template: `<button data-testid="stub-data-filter" @click="$emit('filter', ['x'])">filter</button>`,
     },
     TimestampFilter: true,
-    DataFeature: true,
+    GalleryGrid: {
+      template: "<div data-testid='stub-gallery-grid'><slot /></div>",
+    },
+    GalleryTile: {
+      props: ["testId"],
+      template: `<div :data-testid="testId">tile</div>`,
+    },
     EmptyStateIllustration: {
       props: ["variant"],
       template:
@@ -78,6 +82,7 @@ describe("GalleryView empty states", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     filterByDateAndCategoryMock.mockReset();
+    filterByDateAndCategoryMock.mockImplementation((data: Dataset) => data);
   });
 
   it("shows galleryEmpty when gallery has no items", () => {
@@ -117,5 +122,29 @@ describe("GalleryView empty states", () => {
     expect(wrapper.get('[data-testid="stub-empty-illustration"]').text()).toBe(
       "noFilterResults",
     );
+  });
+});
+
+describe("GalleryView grid rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    filterByDateAndCategoryMock.mockReset();
+    filterByDateAndCategoryMock.mockImplementation((data: Dataset) => data);
+  });
+
+  it("renders gallery tiles when filtered data is present", () => {
+    const wrapper = mount(GalleryView, {
+      props: {
+        ...baseProps,
+        galleryData: [{ _id: "1" }, { _id: "2" }] as unknown as Dataset,
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="stub-gallery-grid"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="gallery-item-0"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="gallery-item-1"]').exists()).toBe(true);
   });
 });

--- a/tests/unit/components/gallery/GalleryGrid.test.ts
+++ b/tests/unit/components/gallery/GalleryGrid.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import GalleryGrid from "@/components/gallery/GalleryGrid.vue";
+
+describe("GalleryGrid", () => {
+  it("renders a responsive 2-column mobile and 4-column desktop grid", () => {
+    const wrapper = mount(GalleryGrid, {
+      slots: {
+        default: "<div data-testid='slot-item'>tile</div>",
+      },
+    });
+
+    const grid = wrapper.get('[data-testid="gallery-grid"]');
+    expect(grid.classes()).toContain("grid-cols-2");
+    expect(grid.classes()).toContain("lg:grid-cols-4");
+    expect(wrapper.find('[data-testid="slot-item"]').exists()).toBe(true);
+  });
+});

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, ref, watchEffect } from "vue";
+
+import GalleryTile from "@/components/gallery/GalleryTile.vue";
+import type { AllowedFileExtensions } from "@/types";
+
+Object.assign(globalThis, {
+  computed,
+  ref,
+  watchEffect,
+});
+
+const mockT = (key: string) => key;
+
+vi.mock("@/composables/useIntersectionObserver", () => ({
+  useIntersectionObserver: () => ({
+    target: ref(null),
+  }),
+}));
+
+vi.mock("@/composables/useOptimizedImages", () => ({
+  useOptimizedImages: () => ({
+    getGalleryImageUrl: (url: string) => url,
+  }),
+}));
+
+vi.mock("@/components/shared/MediaFile.vue", () => ({
+  default: {
+    name: "MediaFile",
+    props: ["filePath", "variant"],
+    template:
+      '<div data-testid="stub-media-file" :data-variant="variant">{{ filePath }}</div>',
+  },
+}));
+
+const allowedFileExtensions: AllowedFileExtensions = {
+  audio: ["mp3", "m4a"],
+  image: ["jpg", "jpeg", "png"],
+  video: ["mp4"],
+};
+
+const globalConfig = {
+  mocks: {
+    $t: mockT,
+  },
+};
+
+describe("GalleryTile", () => {
+  it("renders an image preview inside rounded gallery chrome", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-0",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="gallery-item-0"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stub-media-file"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="stub-media-file"]').text()).toBe(
+      "photo.jpg",
+    );
+    expect(wrapper.find(".rounded-2xl").exists()).toBe(true);
+  });
+
+  it("renders audio preview through MediaFile with gallery variant", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["recording.mp3"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-1",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="stub-media-file"]').text()).toBe(
+      "recording.mp3",
+    );
+    expect(
+      wrapper
+        .find('[data-testid="stub-media-file"]')
+        .attributes("data-variant"),
+    ).toBe("gallery");
+  });
+
+  it("shows a no-media placeholder when file paths are empty", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: [],
+        mediaBasePath: "/media",
+        testId: "gallery-item-2",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="gallery-tile-no-media"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain("galleryNoMedia");
+  });
+});

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -102,5 +102,42 @@ describe("GalleryTile", () => {
       true,
     );
     expect(wrapper.text()).toContain("galleryNoMedia");
+    expect(wrapper.find('[data-testid="gallery-tile-overlay"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("includes a hover overlay with click-to-view-details copy", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-3",
+      },
+      global: globalConfig,
+    });
+
+    const overlay = wrapper.get('[data-testid="gallery-tile-overlay"]');
+    expect(overlay.classes()).toContain("lg:group-hover:opacity-100");
+    expect(overlay.classes()).toContain("lg:group-focus-within:opacity-100");
+    expect(overlay.classes()).toContain("opacity-70");
+    expect(overlay.classes()).toContain("pointer-events-none");
+    expect(overlay.text()).toContain("galleryClickToViewDetails");
+  });
+
+  it("is keyboard focusable for the overlay affordance", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-4",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.attributes("tabindex")).toBe("0");
+    expect(wrapper.attributes("role")).toBe("button");
   });
 });

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -101,6 +101,6 @@ describe("GalleryTile", () => {
     expect(wrapper.find('[data-testid="gallery-tile-no-media"]').exists()).toBe(
       true,
     );
-    expect(wrapper.text()).toContain("galleryNoMedia");
+    expect(wrapper.text()).toContain("galleryEmpty");
   });
 });

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -64,6 +64,7 @@ describe("GalleryTile", () => {
       "photo.jpg",
     );
     expect(wrapper.find(".rounded-2xl").exists()).toBe(true);
+    expect(wrapper.find(".aspect-square").exists()).toBe(true);
   });
 
   it("renders audio preview through MediaFile with gallery variant", () => {

--- a/tests/unit/components/gallery/MediaFile.gallery.test.ts
+++ b/tests/unit/components/gallery/MediaFile.gallery.test.ts
@@ -60,7 +60,7 @@ describe("MediaFile gallery variant", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find("a[data-lightbox]").exists()).toBe(false);
-    expect(wrapper.find(".aspect-square").exists()).toBe(true);
+    expect(wrapper.find(".h-full").exists()).toBe(true);
     expect(wrapper.text()).toContain("loading");
   });
 

--- a/tests/unit/components/gallery/MediaFile.gallery.test.ts
+++ b/tests/unit/components/gallery/MediaFile.gallery.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, ref, watchEffect } from "vue";
+
+import MediaFile from "@/components/shared/MediaFile.vue";
+import type { AllowedFileExtensions } from "@/types";
+
+Object.assign(globalThis, {
+  computed,
+  ref,
+  watchEffect,
+});
+
+const mockT = (key: string) => key;
+
+vi.mock("@/composables/useIntersectionObserver", () => ({
+  useIntersectionObserver: (
+    callback: (entries: IntersectionObserverEntry[]) => void,
+  ) => {
+    const target = ref<HTMLElement | null>(null);
+    watchEffect(() => {
+      if (target.value) {
+        callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+      }
+    });
+    return { target };
+  },
+}));
+
+vi.mock("@/composables/useOptimizedImages", () => ({
+  useOptimizedImages: () => ({
+    getGalleryImageUrl: (url: string) => url,
+  }),
+}));
+
+const allowedFileExtensions: AllowedFileExtensions = {
+  audio: ["mp3", "m4a"],
+  image: ["jpg", "jpeg", "png"],
+  video: ["mp4"],
+};
+
+const globalConfig = {
+  mocks: {
+    $t: mockT,
+  },
+};
+
+describe("MediaFile gallery variant", () => {
+  it("renders gallery images without a lightbox link", async () => {
+    const wrapper = mount(MediaFile, {
+      props: {
+        allowedFileExtensions,
+        filePath: "photo.jpg",
+        mediaBasePath: "/media",
+        variant: "gallery",
+      },
+      global: globalConfig,
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find("a[data-lightbox]").exists()).toBe(false);
+    expect(wrapper.find(".aspect-square").exists()).toBe(true);
+    expect(wrapper.text()).toContain("loading");
+  });
+
+  it("wraps gallery audio in a rounded violet container", () => {
+    const wrapper = mount(MediaFile, {
+      props: {
+        allowedFileExtensions,
+        filePath: "recording.mp3",
+        mediaBasePath: "/media",
+        variant: "gallery",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find("audio").exists()).toBe(true);
+    expect(wrapper.find(".bg-violet-50").exists()).toBe(true);
+    expect(wrapper.find(".rounded-2xl").exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Goal

This PR componentizse grid tiles (4 desktop / 2 mobile)for all media and adds rounded chrome. Closes #447 

## Screenshots

<img width="719" height="554" alt="Screenshot 2026-05-30 at 14 33 48" src="https://github.com/user-attachments/assets/a26a6baa-a1a1-421d-a951-6416effc763d" />
<img width="1470" height="560" alt="Screenshot 2026-05-30 at 14 33 34" src="https://github.com/user-attachments/assets/03634eb0-83b7-4ca3-95e4-c1ab602d5ba4" />


## What I changed and why

- Replaced inline `DataFeature` card rendering in the gallery grid with new `GalleryGrid` and `GalleryTile` components, making the layout media-first
- Gallery now uses a consistent 2-column mobile / 4-column desktop grid layout
- `MediaFile` gains a gallery variant that clips images to a square aspect ratio and wraps audio and video in the same rounded violet frame used elsewhere in the app
- Lightbox link is intentionally omitted on grid images in the gallery variant

## How I convinced myself this is right

The old gallery inlined full `DataFeature` cards, so every entry read like a form with metadata and media mixed together which was the intended design before but no longer works for the media-first layout we want: the grid should be a wall of tiles, not a stack of detail cards. Splitting GalleryGrid (layout only) from GalleryTile (one entry, one preview) keeps pagination, filters, and record caching in GalleryView while giving us a single place to evolve tile chrome later (overlay, carousel) without touching page-level logic again.

Using the first attachment only in the grid matches how we already resolve paths via `getFilePathsWithExtension` and avoids cramming multiple files into one cell before the carousel PR exists. A gallery variant on `MediaFile` instead of forking image/audio markup in the tile reuses lazy loading and extension detection, leaves map/alerts on the default variant unchanged, and drops the lightbox wrapper only where the grid will eventually open a detail panel instead of jQuery lightbox. Square aspect-square tiles give a uniform grid on 2- and 4-column breakpoints without the old 1→2→3→4 column ladder, which was inconsistent with the design spec.

## What I'm not doing here

No hover overlay, detail panel, carousel, filter relocation, or e2e lightbox migration. Map and alerts `MediaFile` behavior is unchanged.

## LLM use disclosure

Mostly for unit stuff. Design was all me.