### PR TITLE
Gallery: hover/focus overlay — dim tile and “Click to view details”

### DIFF
--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -35,9 +35,10 @@ const handleTileKeydown = (event: KeyboardEvent) => {
     @click="handleTileClick"
     @keydown="handleTileKeydown"
   >
-    <div class="relative overflow-hidden rounded-2xl">
+    <div class="relative w-full aspect-square overflow-hidden rounded-2xl">
       <MediaFile
         v-if="previewFilePath"
+        class="h-full w-full"
         :allowed-file-extensions="allowedFileExtensions"
         :file-path="previewFilePath"
         :media-base-path="mediaBasePath"

--- a/components/gallery/GalleryTile.vue
+++ b/components/gallery/GalleryTile.vue
@@ -11,25 +11,59 @@ const props = defineProps<{
 }>();
 
 const previewFilePath = computed(() => props.filePaths[0] ?? null);
+
+const handleTileClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  if (target.closest("audio, video, a")) {
+    return;
+  }
+};
+
+const handleTileKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+  }
+};
 </script>
 
 <template>
-  <div class="overflow-hidden rounded-2xl" :data-testid="testId">
-    <MediaFile
-      v-if="previewFilePath"
-      :allowed-file-extensions="allowedFileExtensions"
-      :file-path="previewFilePath"
-      :media-base-path="mediaBasePath"
-      variant="gallery"
-    />
-    <div
-      v-else
-      class="aspect-square rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center p-4"
-      data-testid="gallery-tile-no-media"
-    >
-      <span class="text-sm text-violet-700 text-center">{{
-        $t("galleryNoMedia")
-      }}</span>
+  <div
+    class="group relative rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2"
+    :data-testid="testId"
+    tabindex="0"
+    role="button"
+    @click="handleTileClick"
+    @keydown="handleTileKeydown"
+  >
+    <div class="relative overflow-hidden rounded-2xl">
+      <MediaFile
+        v-if="previewFilePath"
+        :allowed-file-extensions="allowedFileExtensions"
+        :file-path="previewFilePath"
+        :media-base-path="mediaBasePath"
+        variant="gallery"
+      />
+      <div
+        v-else
+        class="aspect-square rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center p-4"
+        data-testid="gallery-tile-no-media"
+      >
+        <span class="text-sm text-violet-700 text-center">{{
+          $t("galleryNoMedia")
+        }}</span>
+      </div>
+
+      <div
+        v-if="previewFilePath"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-70 transition-opacity duration-300 lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100"
+        data-testid="gallery-tile-overlay"
+      >
+        <span
+          class="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-black/30"
+        >
+          {{ $t("galleryClickToViewDetails") }}
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/components/shared/MediaFile.vue
+++ b/components/shared/MediaFile.vue
@@ -92,7 +92,7 @@ const handleImageLoad = () => {
 
 const imageContainerClass = computed(() => {
   if (isGalleryVariant.value) {
-    return "w-full aspect-square overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-800";
+    return "w-full h-full overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-800";
   }
   return "w-full aspect-video rounded-lg bg-gray-100 dark:bg-gray-800";
 });
@@ -106,11 +106,14 @@ const imageClass = computed(() => {
 </script>
 
 <template>
-  <div>
+  <div :class="{ 'h-full w-full': isGalleryVariant }">
     <div
       v-if="isImage"
       ref="imageContainer"
-      :class="isGalleryVariant ? '' : 'mb-4'"
+      :class="[
+        isGalleryVariant ? 'h-full w-full' : '',
+        isGalleryVariant ? '' : 'mb-4',
+      ]"
     >
       <!-- Error state: Show red X icon when image fails to load (404) -->
       <div
@@ -190,7 +193,7 @@ const imageClass = computed(() => {
       v-if="isAudio"
       :class="
         isGalleryVariant
-          ? 'overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 aspect-square flex items-center'
+          ? 'h-full w-full overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 flex items-center'
           : 'mb-4'
       "
     >
@@ -210,7 +213,7 @@ const imageClass = computed(() => {
       v-if="isVideo"
       :class="
         isGalleryVariant
-          ? 'overflow-hidden rounded-2xl aspect-square bg-gray-100'
+          ? 'h-full w-full overflow-hidden rounded-2xl bg-gray-100'
           : 'mb-4'
       "
     >

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "filtering": "Filtering",
   "filterOutValuesFromColumn": "Which values to filter out from the column",
   "gallery": "Gallery",
+  "galleryClickToViewDetails": "Click to view details",
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryNoFilterResults": "No items match the current filters.",
   "galleryNoMedia": "No media available",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -86,6 +86,7 @@
   "filtering": "Filtrado",
   "filterOutValuesFromColumn": "Qué valores filtrar de la columna",
   "gallery": "Galería",
+  "galleryClickToViewDetails": "Haz clic para ver detalles",
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryNoFilterResults": "Ningún elemento coincide con los filtros actuales.",
   "galleryNoMedia": "No hay medios disponibles",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -87,6 +87,7 @@
   "filtering": "Filteren",
   "filterOutValuesFromColumn": "Welke waarden uit de kolom filteren",
   "gallery": "Galerij",
+  "galleryClickToViewDetails": "Klik om details te bekijken",
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryNoFilterResults": "Geen items komen overeen met de huidige filters.",
   "galleryNoMedia": "Geen media beschikbaar",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -86,6 +86,7 @@
   "filtering": "Filtragem",
   "filterOutValuesFromColumn": "Quais valores filtrar da coluna",
   "gallery": "Galeria",
+  "galleryClickToViewDetails": "Clique para ver detalhes",
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryNoFilterResults": "Nenhum item corresponde aos filtros atuais.",
   "galleryNoMedia": "Nenhuma mídia disponível",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -89,6 +89,7 @@
   "filtering": "Kuchuja",
   "filterOutValuesFromColumn": "Thamani gani za kuchuja kutoka safuni",
   "gallery": "Matunzio",
+  "galleryClickToViewDetails": "Bofya kuona maelezo",
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryNoFilterResults": "Hakuna vipengele vinavyolingana na vichujio vya sasa.",
   "galleryNoMedia": "Hakuna media inayopatikana",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -89,6 +89,7 @@
   "filtering": "การกรอง",
   "filterOutValuesFromColumn": "ค่าที่ต้องการกรองออกจากคอลัมน์",
   "gallery": "แกลเลอรี",
+  "galleryClickToViewDetails": "คลิกเพื่อดูรายละเอียด",
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryNoFilterResults": "ไม่มีรายการตรงกับตัวกรองปัจจุบัน",
   "galleryNoMedia": "ไม่มีสื่อ",

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -102,5 +102,42 @@ describe("GalleryTile", () => {
       true,
     );
     expect(wrapper.text()).toContain("galleryNoMedia");
+    expect(wrapper.find('[data-testid="gallery-tile-overlay"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("includes a hover overlay with click-to-view-details copy", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-3",
+      },
+      global: globalConfig,
+    });
+
+    const overlay = wrapper.get('[data-testid="gallery-tile-overlay"]');
+    expect(overlay.classes()).toContain("lg:group-hover:opacity-100");
+    expect(overlay.classes()).toContain("lg:group-focus-within:opacity-100");
+    expect(overlay.classes()).toContain("opacity-70");
+    expect(overlay.classes()).toContain("pointer-events-none");
+    expect(overlay.text()).toContain("galleryClickToViewDetails");
+  });
+
+  it("is keyboard focusable for the overlay affordance", () => {
+    const wrapper = mount(GalleryTile, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+        testId: "gallery-item-4",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.attributes("tabindex")).toBe("0");
+    expect(wrapper.attributes("role")).toBe("button");
   });
 });

--- a/tests/unit/components/gallery/GalleryTile.test.ts
+++ b/tests/unit/components/gallery/GalleryTile.test.ts
@@ -64,6 +64,7 @@ describe("GalleryTile", () => {
       "photo.jpg",
     );
     expect(wrapper.find(".rounded-2xl").exists()).toBe(true);
+    expect(wrapper.find(".aspect-square").exists()).toBe(true);
   });
 
   it("renders audio preview through MediaFile with gallery variant", () => {

--- a/tests/unit/components/gallery/MediaFile.gallery.test.ts
+++ b/tests/unit/components/gallery/MediaFile.gallery.test.ts
@@ -60,7 +60,7 @@ describe("MediaFile gallery variant", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find("a[data-lightbox]").exists()).toBe(false);
-    expect(wrapper.find(".aspect-square").exists()).toBe(true);
+    expect(wrapper.find(".h-full").exists()).toBe(true);
     expect(wrapper.text()).toContain("loading");
   });
 


### PR DESCRIPTION
## Goal

Adds hover/focus overlay when a user hovers over a grid item. Closes #448 

## Screenshots

<img width="718" height="365" alt="Screenshot 2026-05-30 at 15 06 11" src="https://github.com/user-attachments/assets/cb057aa7-987d-4cd0-abc8-1e51137b5a03" />


## What I changed and why

- Added a dim overlay with "Click to view details" text on hover and keyboard focus inside `GalleryTile`, with no changes to `GalleryView` or the grid layout
- Overlay uses `pointer-events-none` so audio and video controls underneath remain usable
- Tile click handling already ignores clicks on media controls, keeping the path clear for open-detail behavior in a follow-on PR


## How I convinced myself this is right

In my head overlay belongs on the tile, not `GalleryView`, because it is per-item chrome tied to the same rounded media frame https://github.com/ConservationMetrics/gc-explorer/pull/473 introduced.Also, `Pointer-events-none` on the overlay avoids the common trap of blocking audio play buttons while still showing the invite-to-detail copy on hover; 

## What I'm not doing here

No detail panel, no `@open` emit wired in `GalleryView`, no carousel.

## LLM use disclosure
Styling largely me, Opus helped with stuff like i18n