### PR TITLE
fix: load SVG map icons (proxy MIME + canvas rasterization)

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -6,6 +6,7 @@ import { getFilePathsWithExtension } from "@/utils";
 import {
   changeMapStyle,
   applyTerrain,
+  loadMapIcon,
   prepareMapLegendLayers,
   prepareCoordinatesForSelectedFeature,
   toggleLayerVisibility as utilsToggleLayerVisibility,
@@ -386,7 +387,6 @@ const addDataToMap = () => {
 const loadIconImages = async () => {
   if (!props.iconColumn || !props.mediaBasePathIcons || !map.value) return;
 
-  // Get unique icon filenames from data
   const iconFilenames = new Set<string>();
   filteredFeatureCollection.value.features.forEach((feature) => {
     const iconFilename = feature.properties?.[props.iconColumn!];
@@ -395,28 +395,24 @@ const loadIconImages = async () => {
     }
   });
 
-  // Load each unique icon
   for (const filename of iconFilenames) {
     const iconId = `icon-${filename}`;
-    if (!map.value.hasImage(iconId)) {
-      try {
-        // Proxy through our server to avoid CORS issues with Mapbox Canvas API
-        const originalUrl = `${props.mediaBasePathIcons}/${filename}`;
-        const iconUrl = `/api/proxy-icon?url=${encodeURIComponent(originalUrl)}`;
-        const image = await new Promise<HTMLImageElement>((resolve, reject) => {
-          const img = new Image();
-          img.crossOrigin = "anonymous";
-          img.onload = () => resolve(img);
-          img.onerror = reject;
-          img.src = iconUrl;
-        });
-        // Check again before adding (in case of race condition from multiple toggles)
-        if (!map.value.hasImage(iconId)) {
-          map.value.addImage(iconId, image);
-        }
-      } catch (error) {
-        console.error(`Failed to load icon: ${filename}`, error);
+    if (map.value.hasImage(iconId)) continue;
+
+    try {
+      // Proxy through our server to avoid CORS issues with Mapbox Canvas API
+      const originalUrl = `${props.mediaBasePathIcons}/${filename}`;
+      const iconUrl = `/api/proxy-icon?url=${encodeURIComponent(originalUrl)}`;
+      const image = await loadMapIcon(
+        iconUrl,
+        filename.toLowerCase().endsWith(".svg"),
+      );
+      // Re-check before adding in case a concurrent toggle already loaded it
+      if (!map.value.hasImage(iconId)) {
+        map.value.addImage(iconId, image);
       }
+    } catch (error) {
+      console.error(`Failed to load icon: ${filename}`, error);
     }
   }
 };

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -387,6 +387,7 @@ const addDataToMap = () => {
 const loadIconImages = async () => {
   if (!props.iconColumn || !props.mediaBasePathIcons || !map.value) return;
 
+  // Get unique icon filenames from data
   const iconFilenames = new Set<string>();
   filteredFeatureCollection.value.features.forEach((feature) => {
     const iconFilename = feature.properties?.[props.iconColumn!];
@@ -395,6 +396,7 @@ const loadIconImages = async () => {
     }
   });
 
+  // Load each unique icon
   for (const filename of iconFilenames) {
     const iconId = `icon-${filename}`;
     if (map.value.hasImage(iconId)) continue;

--- a/server/api/proxy-icon.get.ts
+++ b/server/api/proxy-icon.get.ts
@@ -3,7 +3,7 @@ import { inferContentType } from "@/utils/mediaHelpers";
 /**
  * Proxy endpoint for loading map icons from external sources (e.g., Filebrowser).
  * Solves CORS issues when Mapbox tries to load images via the Canvas API and
- * normalizes Content-Type (see {@link inferContentType}).
+ * normalizes Content-Type (see inferContentType).
  */
 export default defineEventHandler(async (event) => {
   const url = getQuery(event).url as string | undefined;

--- a/server/api/proxy-icon.get.ts
+++ b/server/api/proxy-icon.get.ts
@@ -1,10 +1,12 @@
+import { inferContentType } from "@/utils/mediaHelpers";
+
 /**
- * Proxy endpoint for loading map icons from external sources (e.g., Filebrowser)
- * This solves CORS issues when Mapbox tries to load images via Canvas API
+ * Proxy endpoint for loading map icons from external sources (e.g., Filebrowser).
+ * Solves CORS issues when Mapbox tries to load images via the Canvas API and
+ * normalizes Content-Type (see {@link inferContentType}).
  */
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event);
-  const url = query.url as string;
+  const url = getQuery(event).url as string | undefined;
 
   if (!url) {
     throw createError({
@@ -13,34 +15,19 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  try {
-    // Fetch the image from the external source
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw createError({
-        statusCode: response.status,
-        statusMessage: `Failed to fetch image: ${response.statusText}`,
-      });
-    }
-
-    // Get the image data
-    const imageBuffer = await response.arrayBuffer();
-    const contentType = response.headers.get("content-type") || "image/png";
-
-    // Set proper headers including CORS
-    setHeaders(event, {
-      "Content-Type": contentType,
-      "Access-Control-Allow-Origin": "*",
-      "Cache-Control": "public, max-age=86400", // Cache for 24 hours
-    });
-
-    // Return the image data
-    return new Uint8Array(imageBuffer);
-  } catch (error) {
+  const response = await fetch(url);
+  if (!response.ok) {
     throw createError({
-      statusCode: 500,
-      statusMessage: `Failed to proxy image: ${error}`,
+      statusCode: response.status,
+      statusMessage: `Failed to fetch image: ${response.statusText}`,
     });
   }
+
+  setHeaders(event, {
+    "Content-Type": inferContentType(url, response.headers.get("content-type")),
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=86400",
+  });
+
+  return new Uint8Array(await response.arrayBuffer());
 });

--- a/tests/unit/utils/mapGLHelpers.test.ts
+++ b/tests/unit/utils/mapGLHelpers.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { loadMapIcon } from "@/utils/mapGLHelpers";
+
+/** Mutated by tests to drive the global `Image` stub for the next `new Image()`. */
+let nextImageState = {
+  shouldFail: false,
+  naturalWidth: 100,
+  naturalHeight: 80,
+};
+
+class StubImage {
+  crossOrigin: string | null = null;
+  onload: (() => void) | null = null;
+  onerror: ((err: unknown) => void) | null = null;
+  naturalWidth = nextImageState.naturalWidth;
+  naturalHeight = nextImageState.naturalHeight;
+  set src(_value: string) {
+    const { shouldFail } = nextImageState;
+    queueMicrotask(() => {
+      if (shouldFail) this.onerror?.(new Error("img load failed"));
+      else this.onload?.();
+    });
+  }
+}
+
+const drawImage = vi.fn();
+const fakeImageData = { width: 0, height: 0 } as ImageData;
+const getImageData = vi.fn(() => fakeImageData);
+
+beforeEach(() => {
+  vi.stubGlobal("Image", StubImage);
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    () =>
+      ({ drawImage, getImageData }) as unknown as CanvasRenderingContext2D,
+  );
+  nextImageState = { shouldFail: false, naturalWidth: 100, naturalHeight: 80 };
+  drawImage.mockClear();
+  getImageData.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("loadMapIcon", () => {
+  it("returns the loaded HTMLImageElement directly for raster icons", async () => {
+    const result = await loadMapIcon("/api/proxy-icon?url=foo.png", false);
+    expect(result).toBeInstanceOf(StubImage);
+    expect(getImageData).not.toHaveBeenCalled();
+  });
+
+  it("rasterizes SVG icons via an offscreen canvas at their natural size", async () => {
+    nextImageState.naturalWidth = 256;
+    nextImageState.naturalHeight = 256;
+
+    const result = await loadMapIcon("/api/proxy-icon?url=foo.svg", true);
+
+    expect(result).toBe(fakeImageData);
+    expect(drawImage).toHaveBeenCalledWith(
+      expect.any(StubImage),
+      0,
+      0,
+      256,
+      256,
+    );
+    expect(getImageData).toHaveBeenCalledWith(0, 0, 256, 256);
+  });
+
+  it("falls back to 64x64 when the SVG has no intrinsic dimensions", async () => {
+    nextImageState.naturalWidth = 0;
+    nextImageState.naturalHeight = 0;
+
+    await loadMapIcon("/api/proxy-icon?url=foo.svg", true);
+
+    expect(getImageData).toHaveBeenCalledWith(0, 0, 64, 64);
+  });
+
+  it("rejects when the image fails to load", async () => {
+    nextImageState.shouldFail = true;
+
+    await expect(
+      loadMapIcon("/api/proxy-icon?url=missing.png", false),
+    ).rejects.toBeDefined();
+  });
+
+  it("throws when a 2D canvas context cannot be obtained", async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+
+    await expect(
+      loadMapIcon("/api/proxy-icon?url=foo.svg", true),
+    ).rejects.toThrow("Failed to get 2D canvas context");
+  });
+});

--- a/tests/unit/utils/mapGLHelpers.test.ts
+++ b/tests/unit/utils/mapGLHelpers.test.ts
@@ -31,8 +31,7 @@ const getImageData = vi.fn(() => fakeImageData);
 beforeEach(() => {
   vi.stubGlobal("Image", StubImage);
   vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
-    () =>
-      ({ drawImage, getImageData }) as unknown as CanvasRenderingContext2D,
+    () => ({ drawImage, getImageData }) as unknown as CanvasRenderingContext2D,
   );
   nextImageState = { shouldFail: false, naturalWidth: 100, naturalHeight: 80 };
   drawImage.mockClear();

--- a/tests/unit/utils/mediaHelpers.test.ts
+++ b/tests/unit/utils/mediaHelpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { inferContentType } from "@/utils/mediaHelpers";
+
+describe("inferContentType", () => {
+  it.each([
+    ["https://files.example.com/api/public/dl/abc/icon.png", "image/png"],
+    ["https://files.example.com/api/public/dl/abc/icon.jpg", "image/jpeg"],
+    ["https://files.example.com/api/public/dl/abc/icon.jpeg", "image/jpeg"],
+    ["https://files.example.com/api/public/dl/abc/icon.gif", "image/gif"],
+    ["https://files.example.com/api/public/dl/abc/icon.svg", "image/svg+xml"],
+    ["https://files.example.com/api/public/dl/abc/icon.webp", "image/webp"],
+  ])("maps %s to the matching MIME type", (url, expected) => {
+    expect(inferContentType(url, null)).toBe(expected);
+  });
+
+  it("matches the extension case-insensitively", () => {
+    expect(
+      inferContentType("https://files.example.com/icon.SVG", null),
+    ).toBe("image/svg+xml");
+  });
+
+  it("ignores query strings and fragments when matching", () => {
+    expect(
+      inferContentType("https://files.example.com/icon.png?v=2#x", null),
+    ).toBe("image/png");
+  });
+
+  it("falls back to the supplied content-type for unknown extensions", () => {
+    expect(
+      inferContentType("https://files.example.com/data.bin", "application/pdf"),
+    ).toBe("application/pdf");
+  });
+
+  it("falls back to application/octet-stream when neither extension nor fallback resolve", () => {
+    expect(inferContentType("https://files.example.com/data", null)).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("falls back for non-URL inputs", () => {
+    expect(inferContentType("not-a-url", "image/png")).toBe("image/png");
+  });
+});

--- a/tests/unit/utils/mediaHelpers.test.ts
+++ b/tests/unit/utils/mediaHelpers.test.ts
@@ -15,9 +15,9 @@ describe("inferContentType", () => {
   });
 
   it("matches the extension case-insensitively", () => {
-    expect(
-      inferContentType("https://files.example.com/icon.SVG", null),
-    ).toBe("image/svg+xml");
+    expect(inferContentType("https://files.example.com/icon.SVG", null)).toBe(
+      "image/svg+xml",
+    );
   });
 
   it("ignores query strings and fragments when matching", () => {

--- a/utils/mapGLHelpers.ts
+++ b/utils/mapGLHelpers.ts
@@ -196,6 +196,40 @@ export const prepareCoordinatesForSelectedFeature = (
     .join(",");
 };
 
+/**
+ * Loads an icon image for Mapbox GL `addImage`. SVGs are rasterized to an
+ * offscreen canvas and returned as `ImageData` because Mapbox's `addImage`
+ * only accepts raster pixel data — uploading an SVG-backed `HTMLImageElement`
+ * silently fails (the texture atlas has no rendered pixel buffer for it).
+ *
+ * @param url Proxied icon URL (must serve CORS-enabled image bytes).
+ * @param isSvg Whether the icon is an SVG and therefore needs rasterization.
+ */
+export const loadMapIcon = async (
+  url: string,
+  isSvg: boolean,
+): Promise<HTMLImageElement | ImageData> => {
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const i = new Image();
+    i.crossOrigin = "anonymous";
+    i.onload = () => resolve(i);
+    i.onerror = reject;
+    i.src = url;
+  });
+
+  if (!isSvg) return img;
+
+  const width = img.naturalWidth || 64;
+  const height = img.naturalHeight || 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to get 2D canvas context");
+  ctx.drawImage(img, 0, 0, width, height);
+  return ctx.getImageData(0, 0, width, height);
+};
+
 /** Toggles the visibility of a map layer */
 export const toggleLayerVisibility = (
   map: mapboxgl.Map,

--- a/utils/mediaHelpers.ts
+++ b/utils/mediaHelpers.ts
@@ -95,6 +95,39 @@ export const isValidFilebrowserInput = (input: string): boolean => {
  * // "abc123" (raw hash), "https://files.localhost/api/public/dl/"
  * // → "https://files.localhost/api/public/dl/"
  */
+const MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+};
+
+/**
+ * Infers an image Content-Type from a URL's file extension, falling back to the
+ * supplied value (typically `response.headers.get('content-type')`) and finally
+ * to `application/octet-stream`.
+ *
+ * Used by the icon proxy because Filebrowser's `/api/public/dl/` endpoint
+ * serves `application/octet-stream`, which the browser refuses to render in an
+ * `<img>` (notably breaks `.svg`).
+ * @example
+ * // "https://files.example.com/api/public/dl/abc/icon.svg", null → "image/svg+xml"
+ */
+export const inferContentType = (
+  url: string,
+  fallback: string | null,
+): string => {
+  try {
+    const ext = new URL(url).pathname.split(".").pop()?.toLowerCase();
+    if (ext && MIME_BY_EXTENSION[ext]) return MIME_BY_EXTENSION[ext];
+  } catch {
+    /* not a valid URL — fall through */
+  }
+  return fallback ?? "application/octet-stream";
+};
+
 export const getBaseUrlFromInput = (
   input: string,
   defaultBaseUrl: string,


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/483. Our API Proxy was not passing the right Content-Type for SVGs, and also SVGs require being rasterized onto a canvas to load onto a Mapbox map. This PR solves both issues.

## Screenshots

<img width="387" height="231" alt="image" src="https://github.com/user-attachments/assets/2b070a85-c77d-4813-a202-45983e459082" />

## What I changed and why

- In `proxy-icon.get.ts`, derive Content-Type from the URL extension. Filebrowser's `/api/public/dl/` returns `application/octet-stream` for everything, which the browser won't accept as an <img> source — that's why SVGs never loaded. Also dropped the outer try/catch that was rewriting upstream 4xx as 500.
- For SVGs, draw the loaded image into an offscreen canvas at its natural size and pass `ImageData` to `addImage`. (Mapbox can't upload SVG-backed `HTMLImageElement` directly.) PNG/JPEG keep the existing zero-copy path.
- Moved `inferContentType` to `utils/mediaHelpers.ts` and `loadMapIcon` to `utils/mapGLHelpers.ts` so they're testable, and added unit tests for both.

## How I convinced myself this is right

- I tested this in production. Both SVG icons, and PNG icons.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Claude Opus 4.7 in Cursor wrote the canvas and test code.